### PR TITLE
Avoid repackaging MSBuild itself and refactor common build logic

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
+    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
+
     <Nullable>enable</Nullable>
 
     <!-- Use the latest version of C# available -->

--- a/build/MSBuildExtensionPackage.targets
+++ b/build/MSBuildExtensionPackage.targets
@@ -1,0 +1,34 @@
+<Project>
+  <PropertyGroup>
+    <BuildOutputTargetFolder>build\</BuildOutputTargetFolder>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <!-- This package contains MSBuild extensions, so avoid dependencies. -->
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+  </PropertyGroup>
+
+  <Import Project="$(RepoRoot)build\MSBuildReference.targets" />
+
+  <!--
+    By default, NuGet includes "framework references" so that packages can import CLR assemblies, but this kind of package does not need them added to
+    projects that reference this package
+  -->
+  <Target Name="RemovePackageFrameworkReferences" AfterTargets="_WalkEachTargetPerFramework">
+    <ItemGroup>
+      <_FrameworkAssemblyReferences Remove="@(_FrameworkAssemblyReferences)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Since this is an MSBuild extension which is loaded into the MSBuild process, much like a tool package we need to repackage our ProjectReferences and PackageReferences -->
+  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage" BeforeTargets="_GetBuildOutputFilesWithTfm" DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild;ResolveProjectReferences">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(_ResolvedProjectReferencePaths)" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+      
+      <!-- Somewhat hard-code this as there isn't a good way to identify it -->
+      <BuildOutputInPackage Include="@(None-&gt;WithMetadataValue('Link', 'native\amd64\rocksdb.dll'))" TargetPath="%(None.Link)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/build/MSBuildReference.targets
+++ b/build/MSBuildReference.targets
@@ -1,0 +1,16 @@
+<Project>
+  <!--
+    Set `MSBuildLibraries` to test against locally built MSBuild, 
+    for example for regression testing pre-release versions of MSBuild.
+  -->
+  <ItemGroup Condition="'$(MSBuildLibraries)' != '' ">
+    <Reference Include="$(MSBuildLibraries)\Microsoft.Build.dll" />
+    <Reference Include="$(MSBuildLibraries)\Microsoft.Build.Framework.dll" />
+    <Reference Include="$(MSBuildLibraries)\Microsoft.Build.Utilities.Core.dll" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(MSBuildLibraries)' == '' ">
+    <PackageReference Include="Microsoft.Build" IncludeAssets="Compile" />
+    <PackageReference Include="Microsoft.Build.Framework" IncludeAssets="Compile" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" IncludeAssets="Compile" />
+  </ItemGroup>
+</Project>

--- a/src/AzureBlobStorage/Microsoft.MSBuildCache.AzureBlobStorage.csproj
+++ b/src/AzureBlobStorage/Microsoft.MSBuildCache.AzureBlobStorage.csproj
@@ -4,11 +4,6 @@
     <Platform>x64</Platform>
     <Platforms>$(Platform)</Platforms>
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
-    <BuildOutputTargetFolder>build\</BuildOutputTargetFolder>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <DevelopmentDependency>true</DevelopmentDependency>
-    <!-- This package contains MSBuild tasks only, so avoid dependencies. -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\Microsoft.MSBuildCache.Common.csproj" />
@@ -37,27 +32,5 @@
       <PackagePath>buildMultiTargeting\</PackagePath>
     </None>
   </ItemGroup>
-
-  <!--
-    By default, NuGet includes "framework references" so that packages can import CLR assemblies, but this kind of package does not need them added to
-    projects that reference this package
-  -->
-  <Target Name="RemovePackageFrameworkReferences" AfterTargets="_WalkEachTargetPerFramework">
-    <ItemGroup>
-      <_FrameworkAssemblyReferences Remove="@(_FrameworkAssemblyReferences)" />
-    </ItemGroup>
-  </Target>
-
-  <!-- Since this is an MSBuild cache plugin, we need to repackage our ProjectReferences and PackageReferences -->
-  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage" BeforeTargets="_GetBuildOutputFilesWithTfm" DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild;ResolveProjectReferences">
-    <ItemGroup>
-      <BuildOutputInPackage Include="@(_ResolvedProjectReferencePaths)" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-      
-      <!-- Somewhat hard-code this as there isn't a good way to identify it -->
-      <BuildOutputInPackage Include="@(None-&gt;WithMetadataValue('Link', 'native\amd64\rocksdb.dll'))" TargetPath="%(None.Link)" />
-    </ItemGroup>
-  </Target>
+  <Import Project="$(RepoRoot)build\MSBuildExtensionPackage.targets" />
 </Project>

--- a/src/AzurePipelines/Microsoft.MSBuildCache.AzurePipelines.csproj
+++ b/src/AzurePipelines/Microsoft.MSBuildCache.AzurePipelines.csproj
@@ -4,11 +4,6 @@
     <Platform>x64</Platform>
     <Platforms>$(Platform)</Platforms>
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
-    <BuildOutputTargetFolder>build\</BuildOutputTargetFolder>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <DevelopmentDependency>true</DevelopmentDependency>
-    <!-- This package contains MSBuild tasks only, so avoid dependencies. -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\Microsoft.MSBuildCache.Common.csproj" />
@@ -35,27 +30,5 @@
       <PackagePath>buildMultiTargeting\</PackagePath>
     </None>
   </ItemGroup>
-
-  <!--
-    By default, NuGet includes "framework references" so that packages can import CLR assemblies, but this kind of package does not need them added to
-    projects that reference this package
-  -->
-  <Target Name="RemovePackageFrameworkReferences" AfterTargets="_WalkEachTargetPerFramework">
-    <ItemGroup>
-      <_FrameworkAssemblyReferences Remove="@(_FrameworkAssemblyReferences)" />
-    </ItemGroup>
-  </Target>
-
-  <!-- Since this is an MSBuild cache plugin, we need to repackage our ProjectReferences and PackageReferences -->
-  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage" BeforeTargets="_GetBuildOutputFilesWithTfm" DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild;ResolveProjectReferences">
-    <ItemGroup>
-      <BuildOutputInPackage Include="@(_ResolvedProjectReferencePaths)" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-      
-      <!-- Somewhat hard-code this as there isn't a good way to identify it -->
-      <BuildOutputInPackage Include="@(None-&gt;WithMetadataValue('Link', 'native\amd64\rocksdb.dll'))" TargetPath="%(None.Link)" />
-    </ItemGroup>
-  </Target>
+  <Import Project="$(RepoRoot)build\MSBuildExtensionPackage.targets" />
 </Project>

--- a/src/Common/Microsoft.MSBuildCache.Common.csproj
+++ b/src/Common/Microsoft.MSBuildCache.Common.csproj
@@ -26,17 +26,5 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.MSBuildCache.Common.Tests" />
   </ItemGroup>
-
-  <!--
-    Set `MSBuildLibraries` to test against locally built MSBuild, 
-    for example for regression testing pre-release versions of MSBuild.
-  -->
-  <ItemGroup Condition="'$(MSBuildLibraries)' != '' ">
-    <Reference Include="$(MSBuildLibraries)\Microsoft.Build.dll" />
-    <Reference Include="$(MSBuildLibraries)\Microsoft.Build.Framework.dll" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(MSBuildLibraries)' == '' ">
-    <PackageReference Include="Microsoft.Build" />
-    <PackageReference Include="Microsoft.Build.Framework" />
-  </ItemGroup>
+  <Import Project="$(RepoRoot)build\MSBuildReference.targets" />
 </Project>

--- a/src/Local/Microsoft.MSBuildCache.Local.csproj
+++ b/src/Local/Microsoft.MSBuildCache.Local.csproj
@@ -4,11 +4,6 @@
     <Platform>x64</Platform>
     <Platforms>$(Platform)</Platforms>
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
-    <BuildOutputTargetFolder>build\</BuildOutputTargetFolder>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <DevelopmentDependency>true</DevelopmentDependency>
-    <!-- This package contains MSBuild tasks only, so avoid dependencies. -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\Microsoft.MSBuildCache.Common.csproj" />
@@ -37,27 +32,5 @@
       <PackagePath>buildMultiTargeting\</PackagePath>
     </None>
   </ItemGroup>
-
-  <!--
-    By default, NuGet includes "framework references" so that packages can import CLR assemblies, but this kind of package does not need them added to
-    projects that reference this package
-  -->
-  <Target Name="RemovePackageFrameworkReferences" AfterTargets="_WalkEachTargetPerFramework">
-    <ItemGroup>
-      <_FrameworkAssemblyReferences Remove="@(_FrameworkAssemblyReferences)" />
-    </ItemGroup>
-  </Target>
-
-  <!-- Since this is an MSBuild cache plugin, we need to repackage our ProjectReferences and PackageReferences -->
-  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage" BeforeTargets="_GetBuildOutputFilesWithTfm" DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild;ResolveProjectReferences">
-    <ItemGroup>
-      <BuildOutputInPackage Include="@(_ResolvedProjectReferencePaths)" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-      
-      <!-- Somewhat hard-code this as there isn't a good way to identify it -->
-      <BuildOutputInPackage Include="@(None-&gt;WithMetadataValue('Link', 'native\amd64\rocksdb.dll'))" TargetPath="%(None.Link)" />
-    </ItemGroup>
-  </Target>
+  <Import Project="$(RepoRoot)build\MSBuildExtensionPackage.targets" />
 </Project>

--- a/src/SharedCompilation/Microsoft.MSBuildCache.SharedCompilation.csproj
+++ b/src/SharedCompilation/Microsoft.MSBuildCache.SharedCompilation.csproj
@@ -4,11 +4,6 @@
     <Platform>x64</Platform>
     <Platforms>$(Platform)</Platforms>
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
-    <BuildOutputTargetFolder>build\</BuildOutputTargetFolder>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <DevelopmentDependency>true</DevelopmentDependency>
-    <!-- This package contains MSBuild tasks only, so avoid dependencies. -->
-    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" />
@@ -25,38 +20,5 @@
       <PackagePath>buildMultiTargeting\</PackagePath>
     </None>
   </ItemGroup>
-
-  <!--
-    Set `MSBuildLibraries` to test against locally built MSBuild, 
-    for example for regression testing pre-release versions of MSBuild.
-  -->
-  <!-- TODO: Remove the reference to Microsoft.Build once there is a cleaner task interface for reporting file accesses -->
-  <ItemGroup Condition="'$(MSBuildLibraries)' != '' ">
-    <Reference Include="$(MSBuildLibraries)\Microsoft.Build.dll" />
-    <Reference Include="$(MSBuildLibraries)\Microsoft.Build.Framework.dll" />
-    <Reference Include="$(MSBuildLibraries)\Microsoft.Build.Utilities.Core.dll" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(MSBuildLibraries)' == '' ">
-    <PackageReference Include="Microsoft.Build" />
-    <PackageReference Include="Microsoft.Build.Framework" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" />
-  </ItemGroup>
-
-  <!--
-    By default, NuGet includes "framework references" so that packages can import CLR assemblies, but this kind of package does not need them added to
-    projects that reference this package
-  -->
-  <Target Name="RemovePackageFrameworkReferences" AfterTargets="_WalkEachTargetPerFramework">
-    <ItemGroup>
-      <_FrameworkAssemblyReferences Remove="@(_FrameworkAssemblyReferences)" />
-    </ItemGroup>
-  </Target>
-
-  <!-- Since this is an MSBuild task, we need to repackage our PackageReferences -->
-  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage" BeforeTargets="_GetBuildOutputFilesWithTfm" DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild">
-    <ItemGroup>
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-    </ItemGroup>
-  </Target>
+  <Import Project="$(RepoRoot)build\MSBuildExtensionPackage.targets" />
 </Project>


### PR DESCRIPTION
Avoid repackaging MSBuild itself and refactor common build logic

The primary change is to avoid repackaging MSBuild by adding `IncludeAssets="Compile"`. However this needs to be done in each project (inheriting from a ProjectReference doesn't apply it?), so I went ahead and just extracted the reference and other common logic into a separate targets file.