### PR TITLE
Remove SourceLink package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,7 +47,6 @@
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.5.113" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This functionality is included in .NET 8.0.100, so doesn't need to be explicitly referenced.