### PR TITLE
Set ContinuousIntegrationBuild in YAML

### DIFF
--- a/.azuredevops/pipelines/templates/build.yml
+++ b/.azuredevops/pipelines/templates/build.yml
@@ -25,7 +25,7 @@ steps:
   inputs:
     command: build
     projects: ${{ parameters.RepoRoot }}/MSBuildCache.sln
-    arguments: -restore:false --configuration $(BuildConfiguration) -BinaryLogger:$(LogDirectory)/msbuild.binlog
+    arguments: -restore:false --configuration $(BuildConfiguration) -BinaryLogger:$(LogDirectory)/msbuild.binlog -p:ContinuousIntegrationBuild=true
 
 - task: PublishBuildArtifacts@1
   displayName: Publish Logs


### PR DESCRIPTION
This enables some features of SourceLink and the SDK that improve determinism of build outputs. NuGet Package Explorer will flag a package that doesn't have it on.