### PR TITLE
Restore timestamps for duplicate binplace files

### DIFF
--- a/src/AzurePipelines/PipelineCachingCacheClient.cs
+++ b/src/AzurePipelines/PipelineCachingCacheClient.cs
@@ -461,6 +461,7 @@ internal sealed class PipelineCachingCacheClient : CacheClient
             {
                 if (file.Value.LastModifiedUTC != null)
                 {
+                    _client.Tracer.Debug(context, $"Setting last modified time for `{file.Key.Path}` to `{file.Value.LastModifiedUTC.Value}`.");
                     File.SetLastWriteTimeUtc(file.Key.Path, file.Value.LastModifiedUTC.Value);
                 }
             }

--- a/src/AzurePipelines/PipelineCachingCacheClient.cs
+++ b/src/AzurePipelines/PipelineCachingCacheClient.cs
@@ -456,6 +456,14 @@ internal sealed class PipelineCachingCacheClient : CacheClient
             },
             context: context.ToString()!,
             cancellationToken);
+
+            foreach (KeyValuePair<AbsolutePath, FilePlacement> file in files)
+            {
+                if (file.Value.LastModifiedUTC != null)
+                {
+                    File.SetLastWriteTimeUtc(file.Key.Path, file.Value.LastModifiedUTC.Value);
+                }
+            }
         }
     }
 

--- a/src/Common.Tests/NodeBuildResultTests.cs
+++ b/src/Common.Tests/NodeBuildResultTests.cs
@@ -7,17 +7,16 @@ using MoreLinq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 
 namespace Microsoft.MSBuildCache.Tests;
 
 [TestClass]
 public class NodeBuildResultTests
 {
-    private static readonly Dictionary<string, (DateTime, ContentHash)> Outputs = new(){
-        {"Lib-link.write.1.tlog", (DateTime.UtcNow, ContentHash.Random())},
-        {"Lib.command.1.tlog", (DateTime.UtcNow, ContentHash.Random())},
-        {"logger.lastbuildstate", (DateTime.UtcNow, ContentHash.Random())},
+    private static readonly Dictionary<string, OutputInfo> Outputs = new(){
+        {"Lib-link.write.1.tlog", new OutputInfo(DateTime.UtcNow, ContentHash.Random())},
+        {"Lib.command.1.tlog", new OutputInfo(DateTime.UtcNow, ContentHash.Random())},
+        {"logger.lastbuildstate", new OutputInfo(DateTime.UtcNow, ContentHash.Random())},
     };
 
     [TestMethod]
@@ -36,11 +35,11 @@ public class NodeBuildResultTests
     public void SortWorksConsistentlyAcrossJson()
     {
         List<string> names = Outputs.Keys.ToList();
-        var expected = new SortedDictionary<string, (DateTime, ContentHash)>(Outputs, StringComparer.OrdinalIgnoreCase);
+        var expected = new SortedDictionary<string, OutputInfo>(Outputs, StringComparer.OrdinalIgnoreCase);
 
         foreach (IList<string> permutation in names.Permutations())
         {
-            var maybeMixed = new SortedDictionary<string, (DateTime, ContentHash)>(
+            var maybeMixed = new SortedDictionary<string, OutputInfo>(
                 permutation.ToDictionary(name => name, name => Outputs[name]));
 
             NodeBuildResult nodeBuildResult = new(
@@ -51,8 +50,8 @@ public class NodeBuildResultTests
                 null
             );
 
-            string serialized = JsonSerializer.Serialize(nodeBuildResult);
-            NodeBuildResult deserialized = JsonSerializer.Deserialize<NodeBuildResult>(serialized)!;
+            string serialized = SerializationHelper.Serialize(nodeBuildResult);
+            NodeBuildResult deserialized = SerializationHelper.Deserialize<NodeBuildResult>(serialized)!;
 
             CollectionAssert.AreEqual(expected.Keys, deserialized.Outputs.Keys, "\n" +
                 "Permutation: " + string.Join(", ", permutation) + "\n" +

--- a/src/Common.Tests/NodeBuildResultTests.cs
+++ b/src/Common.Tests/NodeBuildResultTests.cs
@@ -14,10 +14,10 @@ namespace Microsoft.MSBuildCache.Tests;
 [TestClass]
 public class NodeBuildResultTests
 {
-    private static readonly Dictionary<string, ContentHash> Outputs = new Dictionary<string, ContentHash> {
-        {"Lib-link.write.1.tlog", ContentHash.Random()},
-        {"Lib.command.1.tlog", ContentHash.Random()},
-        {"logger.lastbuildstate", ContentHash.Random()},
+    private static readonly Dictionary<string, (DateTime, ContentHash)> Outputs = new(){
+        {"Lib-link.write.1.tlog", (DateTime.UtcNow, ContentHash.Random())},
+        {"Lib.command.1.tlog", (DateTime.UtcNow, ContentHash.Random())},
+        {"logger.lastbuildstate", (DateTime.UtcNow, ContentHash.Random())},
     };
 
     [TestMethod]
@@ -36,11 +36,11 @@ public class NodeBuildResultTests
     public void SortWorksConsistentlyAcrossJson()
     {
         List<string> names = Outputs.Keys.ToList();
-        var expected = new SortedDictionary<string, ContentHash>(Outputs, StringComparer.OrdinalIgnoreCase);
+        var expected = new SortedDictionary<string, (DateTime, ContentHash)>(Outputs, StringComparer.OrdinalIgnoreCase);
 
         foreach (IList<string> permutation in names.Permutations())
         {
-            var maybeMixed = new SortedDictionary<string, ContentHash>(
+            var maybeMixed = new SortedDictionary<string, (DateTime, ContentHash)>(
                 permutation.ToDictionary(name => name, name => Outputs[name]));
 
             NodeBuildResult nodeBuildResult = new(

--- a/src/Common/Caching/CacheClient.cs
+++ b/src/Common/Caching/CacheClient.cs
@@ -361,7 +361,7 @@ public abstract class CacheClient : ICacheClient
         }
 
         Dictionary<AbsolutePath, FilePlacement> placements = new();
-        foreach (KeyValuePair<string, (DateTime LastModified, ContentHash Hash)> output in nodeBuildResult.Outputs)
+        foreach (KeyValuePair<string, OutputInfo> output in nodeBuildResult.Outputs)
         {
             AbsolutePath outputPath = RepoRoot / output.Key;
             FileRealizationMode realizationMode = GetFileRealizationMode(outputPath.Path);

--- a/src/Common/Caching/CasCacheClient.cs
+++ b/src/Common/Caching/CasCacheClient.cs
@@ -472,6 +472,7 @@ public sealed class CasCacheClient : CacheClient
                     throw new ArgumentException($"Can only set LastModifiedUTC with FileRealizationMode.Copy {filePath}.");
                 }
 
+                Tracer.Debug(context, $"Setting last modified time for `{filePath.Path}` to `{placement.LastModifiedUTC.Value}`.");
                 File.SetLastWriteTimeUtc(filePath.Path, placement.LastModifiedUTC.Value);
             }
             // Ensure we don't attempt to put content we successfully placed, since we know the cache has it.

--- a/src/Common/Fingerprinting/FingerprintFactory.cs
+++ b/src/Common/Fingerprinting/FingerprintFactory.cs
@@ -122,9 +122,9 @@ public sealed class FingerprintFactory : IFingerprintFactory
                     NodeContext dependency = kvp.Value;
 
                     // Sort outputs for consistent hash ordering
-                    foreach (KeyValuePair<string, ContentHash> dependencyOutput in dependency.BuildResult!.Outputs)
+                    foreach (KeyValuePair<string, (DateTime LastModified, ContentHash Hash)> dependencyOutput in dependency.BuildResult!.Outputs)
                     {
-                        entries.Add(new FingerprintEntry(dependencyOutput.Value.ToHashByteArray(), $"Dependency Output: {dependency.Id} - {dependencyOutput.Key}"));
+                        entries.Add(new FingerprintEntry(dependencyOutput.Value.Hash.ToHashByteArray(), $"Dependency Output: {dependency.Id} - {dependencyOutput.Key}"));
                     }
                 }
 

--- a/src/Common/Fingerprinting/FingerprintFactory.cs
+++ b/src/Common/Fingerprinting/FingerprintFactory.cs
@@ -122,7 +122,7 @@ public sealed class FingerprintFactory : IFingerprintFactory
                     NodeContext dependency = kvp.Value;
 
                     // Sort outputs for consistent hash ordering
-                    foreach (KeyValuePair<string, (DateTime LastModified, ContentHash Hash)> dependencyOutput in dependency.BuildResult!.Outputs)
+                    foreach (KeyValuePair<string, OutputInfo> dependencyOutput in dependency.BuildResult!.Outputs)
                     {
                         entries.Add(new FingerprintEntry(dependencyOutput.Value.Hash.ToHashByteArray(), $"Dependency Output: {dependency.Id} - {dependencyOutput.Key}"));
                     }

--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -563,13 +563,13 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
             normalizedOutputPaths.Keys,
             absolutePathToHash =>
             {
-                SortedDictionary<string, (DateTime LastModified, ContentHash Hash)> outputs = new(StringComparer.OrdinalIgnoreCase);
+                SortedDictionary<string, OutputInfo> outputs = new(StringComparer.OrdinalIgnoreCase);
 
                 foreach (KeyValuePair<string, ContentHash> absolutePathAndHash in absolutePathToHash)
                 {
                     outputs.Add(
                         normalizedOutputPaths[absolutePathAndHash.Key], // so we map back to normalized paths
-                        (File.GetLastWriteTimeUtc(absolutePathAndHash.Key), absolutePathAndHash.Value));
+                        new OutputInfo(File.GetLastWriteTimeUtc(absolutePathAndHash.Key), absolutePathAndHash.Value));
                 }
 
                 CheckForDuplicateOutputs(logger, outputs, nodeContext);
@@ -896,9 +896,9 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
         return false;
     }
 
-    private void CheckForDuplicateOutputs(PluginLoggerBase logger, IReadOnlyDictionary<string, (DateTime LastModified, ContentHash Hash)> normalizedFilePathToHash, NodeContext nodeContext)
+    private void CheckForDuplicateOutputs(PluginLoggerBase logger, IReadOnlyDictionary<string, OutputInfo> normalizedFilePathToHash, NodeContext nodeContext)
     {
-        foreach (KeyValuePair<string, (DateTime LastModified, ContentHash Hash)> kvp in normalizedFilePathToHash)
+        foreach (KeyValuePair<string, OutputInfo> kvp in normalizedFilePathToHash)
         {
             string normalizedFilePath = kvp.Key;
             ContentHash newHash = kvp.Value.Hash;

--- a/src/Common/NodeBuildResult.cs
+++ b/src/Common/NodeBuildResult.cs
@@ -17,7 +17,7 @@ public sealed class NodeBuildResult
 
     [JsonConstructor]
     public NodeBuildResult(
-        SortedDictionary<string, ContentHash> outputs,
+        SortedDictionary<string, (DateTime LastModified, ContentHash Hash)> outputs,
         IReadOnlyList<NodeTargetResult> targetResults,
         DateTime startTimeUtc,
         DateTime endTimeUtc,
@@ -32,7 +32,7 @@ public sealed class NodeBuildResult
 
     // Use a sorted dictionary so the JSON output is deterministically sorted and easier to compare build-to-build.
     [JsonConverter(typeof(SortedDictionaryConverter))]
-    public SortedDictionary<string, ContentHash> Outputs { get; }
+    public SortedDictionary<string, (DateTime LastModified, ContentHash Hash)> Outputs { get; }
 
     public IReadOnlyList<NodeTargetResult> TargetResults { get; }
 
@@ -42,7 +42,7 @@ public sealed class NodeBuildResult
 
     public string? BuildId { get; }
 
-    public static NodeBuildResult FromBuildResult(SortedDictionary<string, ContentHash> outputs, BuildResult buildResult, DateTime creationTimeUtc, DateTime endTimeUtc, string? buildId, PathNormalizer pathNormalizer)
+    public static NodeBuildResult FromBuildResult(SortedDictionary<string, (DateTime LastModified, ContentHash Hash)> outputs, BuildResult buildResult, DateTime creationTimeUtc, DateTime endTimeUtc, string? buildId, PathNormalizer pathNormalizer)
     {
         List<NodeTargetResult> targetResults = new(buildResult.ResultsByTarget.Count);
         foreach (KeyValuePair<string, TargetResult> kvp in buildResult.ResultsByTarget)


### PR DESCRIPTION
For files that are written multiple times, make sure to restore the timestamp so that `SkipUnchangedFiles` works.

Unfortunately, timestamps and hard-links don't play well.