### PR TITLE
Consider tagged refs as public releases

### DIFF
--- a/src/SharedCompilation/Microsoft.MSBuildCache.SharedCompilation.csproj
+++ b/src/SharedCompilation/Microsoft.MSBuildCache.SharedCompilation.csproj
@@ -20,5 +20,9 @@
       <PackagePath>buildMultiTargeting\</PackagePath>
     </None>
   </ItemGroup>
+  <!-- Signing -->
+  <ItemGroup>
+    <FilesToSign Include="$(TargetPath)" Authenticode="Microsoft400" StrongName="StrongName" />
+  </ItemGroup>
   <Import Project="$(RepoRoot)build\MSBuildExtensionPackage.targets" />
 </Project>

--- a/version.json
+++ b/version.json
@@ -4,7 +4,8 @@
   // For historical reasons, use a specific offset. Reset to -1 when bumping the version above.
   "buildNumberOffset": 204,
   "publicReleaseRefSpec": [
-    "^refs/heads/main$"
+    "^refs/heads/main$",
+    "^refs/tags/v\\d+\\.\\d+\\.\\d+"
   ],
   "inherit": false
 }


### PR DESCRIPTION
This should fix the version we push to nuget.org from something like `0.1.223-preview-g7f2aa10a8b` to something like `0.1.223-preview`.

Also fix signing for the SharedCompilation package