### PR TITLE
Add option to force cache miss

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ These settings are common across all plugins, although different implementations
 | `$(MSBuildCacheMaxConcurrentCacheContentOperations)` | `int` | 64 | The maximum number of cache operations to perform concurrently |
 | `$(MSBuildCacheLocalCacheRootPath)` | `string` | "\MSBuildCache" (in repo's drive root) | Base directory to use for the local cache. |
 | `$(MSBuildCacheLocalCacheSizeInMegabytes)` | `int` | 102400 (100 GB) | The maximum size in megabytes of the local cache |
+| `$(ForceCacheMissPercentage)` | `int` | 0 | Force a cache miss a percentage of the time. Useful for testing to simulate natural cache misses. |
 | `$(MSBuildCacheIgnoredInputPatterns)` | `Glob[]` |  | Files which are part of the repo which should be ignored for cache invalidation |
 | `$(MSBuildCacheIgnoredOutputPatterns)` | `Glob[]` | `*.assets.cache; *assemblyreference.cache` | Files to ignore for output collection into the cache. Note that if output are ignored, the replayed cache entry will not have these files. This should be used for intermediate outputs which are not properly portable |
 | `$(MSBuildCacheIdenticalDuplicateOutputPatterns)` | `Glob[]` | | Files to allow duplicate outputs, with identical content, across projects. Projects which produce files at the same path with differing content will still produce an error. Note: this setting should be used sparingly as it impacts performance |

--- a/src/Common.Tests/PluginSettingsTests.cs
+++ b/src/Common.Tests/PluginSettingsTests.cs
@@ -95,7 +95,7 @@ public sealed class PluginSettingsTests
             new[] { 123u, 456u, 789u });
 
     [TestMethod]
-    public void ForceCacheMissBitMaskSetting()
+    public void ForceCacheMissPercentageSetting()
         => TestBasicSetting(
             nameof(PluginSettings.ForceCacheMissPercentage),
             pluginSettings => pluginSettings.ForceCacheMissPercentage,

--- a/src/Common.Tests/PluginSettingsTests.cs
+++ b/src/Common.Tests/PluginSettingsTests.cs
@@ -94,6 +94,13 @@ public sealed class PluginSettingsTests
             pluginSettings => pluginSettings.LocalCacheSizeInMegabytes,
             new[] { 123u, 456u, 789u });
 
+    [TestMethod]
+    public void ForceCacheMissBitMaskSetting()
+        => TestBasicSetting(
+            nameof(PluginSettings.ForceCacheMissPercentage),
+            pluginSettings => pluginSettings.ForceCacheMissPercentage,
+            new[] { 0u, 10u, 100u });
+
     private static IEnumerable<object[]> GlobTestData
     {
         get

--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -355,11 +355,15 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
         if (Settings.ForceCacheMissPercentage != 0)
         {
             // use a hash of the project id so that it is repeatable
-#pragma warning disable CA1850 // ComputeHash is not in net472
+
+#if NETFRAMEWORK
             using SHA256 hasher = SHA256.Create();
             byte[] projectHash = hasher.ComputeHash(Encoding.UTF8.GetBytes(nodeContext.Id));
+#else
+            byte[] projectHash = SHA256.HashData(Encoding.UTF8.GetBytes(nodeContext.Id));
+#endif
+
             uint hashInt = BitConverter.ToUInt32(projectHash, 0);
-#pragma warning restore CA1850
             if ((hashInt % 100) < Settings.ForceCacheMissPercentage)
             {
                 logger.LogMessage($"Forcing an otherwise 'cache hit' to be a 'cache miss' because of ForceCacheMissPercentage.");

--- a/src/Common/PluginSettings.cs
+++ b/src/Common/PluginSettings.cs
@@ -81,6 +81,8 @@ public class PluginSettings
 
     public uint LocalCacheSizeInMegabytes { get; init; } = 102400; // 100GB
 
+    public uint ForceCacheMissPercentage { get; init; }
+
     public IReadOnlyCollection<Glob> IgnoredInputPatterns { get; init; } = Array.Empty<Glob>();
 
     public IReadOnlyCollection<Glob> IgnoredOutputPatterns { get; init; } = Array.Empty<Glob>();

--- a/src/Common/build/Microsoft.MSBuildCache.Common.targets
+++ b/src/Common/build/Microsoft.MSBuildCache.Common.targets
@@ -10,6 +10,7 @@
     <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheMaxConcurrentCacheContentOperations</MSBuildCacheGlobalPropertiesToIgnore>
     <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheLocalCacheRootPath</MSBuildCacheGlobalPropertiesToIgnore>
     <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheLocalCacheSizeInMegabytes</MSBuildCacheGlobalPropertiesToIgnore>
+    <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheForceCacheMissPercentage</MSBuildCacheGlobalPropertiesToIgnore>
     <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheIgnoredInputPatterns</MSBuildCacheGlobalPropertiesToIgnore>
     <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheIgnoredOutputPatterns</MSBuildCacheGlobalPropertiesToIgnore>
     <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheIdenticalDuplicateOutputPatterns</MSBuildCacheGlobalPropertiesToIgnore>
@@ -29,6 +30,7 @@
       <MaxConcurrentCacheContentOperations>$(MSBuildCacheMaxConcurrentCacheContentOperations)</MaxConcurrentCacheContentOperations>
       <LocalCacheRootPath>$(MSBuildCacheLocalCacheRootPath)</LocalCacheRootPath>
       <LocalCacheSizeInMegabytes>$(MSBuildCacheLocalCacheSizeInMegabytes)</LocalCacheSizeInMegabytes>
+      <ForceCacheMissPercentage>$(MSBuildCacheForceCacheMissPercentage)</ForceCacheMissPercentage>
       <IgnoredInputPatterns>$(MSBuildCacheIgnoredInputPatterns)</IgnoredInputPatterns>
       <IgnoredOutputPatterns>$(MSBuildCacheIgnoredOutputPatterns)</IgnoredOutputPatterns>
       <IdenticalDuplicateOutputPatterns>$(MSBuildCacheIdenticalDuplicateOutputPatterns)</IdenticalDuplicateOutputPatterns>

--- a/src/Local/MSBuildCacheLocalPlugin.cs
+++ b/src/Local/MSBuildCacheLocalPlugin.cs
@@ -38,7 +38,6 @@ public sealed class MSBuildCacheLocalPlugin : MSBuildCachePluginBase
 #pragma warning restore CA2000 // Dispose objects before losing scope
         Context context = new(cacheLogger);
 
-
 #pragma warning disable CA2000 // Dispose objects before losing scope. Expected to be disposed by TwoLevelCache
         LocalCache cache = LocalCacheFactory.Create(cacheLogger, Settings.LocalCacheRootPath, Settings.LocalCacheSizeInMegabytes);
 #pragma warning restore CA2000 // Dispose objects before losing scope


### PR DESCRIPTION
When onboarding a new repo, it's useful to simulate natural load to flush out potential problems from project non-determinism.  This adds a test flag to force cache misses in a semi-random, but deterministic way.