### PR TITLE
Stop filtering file accesses not under the repo root

### DIFF
--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -393,13 +393,6 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
             return;
         }
 
-        // Ignore file accesses outside the repository
-        ReadOnlySpan<char> path = PathHelper.RemoveLongPathPrefixes(fileAccessData.Path.AsSpan());
-        if (!path.StartsWith(_repoRoot.AsSpan(), StringComparison.OrdinalIgnoreCase))
-        {
-            return;
-        }
-
         NodeContext? nodeContext = GetNodeContext(fileAccessContext);
         if (nodeContext == null)
         {
@@ -496,6 +489,7 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
             string? normalizedFilePath = absolutePath.MakePathRelativeTo(_repoRoot!);
             if (normalizedFilePath == null)
             {
+                // Ignore inputs outside the repository
                 continue;
             }
 


### PR DESCRIPTION
I noticed that copies of nuget package contents only showed the destination of the copy and not the source. The reason was that we are filtering out any file access outside the repo. This was a bad early decision probably originally to help scope down the file access logs.

We will almost certainly want to start considering file accesses outside the repo, for example the package cache. Actual handling of those inputs will come in a future change though.