### PR TITLE
Create dummy git repo for e2e test for proper hashing

### DIFF
--- a/tests/TestProject/.gitignore
+++ b/tests/TestProject/.gitignore
@@ -1,3 +1,5 @@
 nuget_packages
 MSBuildCache
 MSBuildCacheLogs*
+obj/
+bin/

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -184,6 +184,16 @@ $ProjectDir = Join-Path $TestRoot "src"
 Remove-Item -Path $TestRoot -Recurse -Force -ErrorAction SilentlyContinue
 Copy-Item -Path (Join-Path $PSScriptRoot "TestProject") -Destination $ProjectDir -Recurse
 
+# Create a new git repo with an initial commit so hashing works properly
+Write-Host "Creating Git repo in $ProjectDir"
+Push-Location $ProjectDir
+& git init
+& git config user.email "$Env:UserName@microsoft.com"
+& git config user.name "$Env:UserName"
+& git add .
+& git commit -m "Dummy"
+Pop-Location
+
 Run-Test `
     -TestName "ColdCache" `
     -ExpectedCacheHits 0 `


### PR DESCRIPTION
Previously the fingerprints would be mostly empty due to the temp location it was running in not being included in the parent git repo. This creates a new git repo in the directory where the test source is copied to.