### PR TITLE
Fix prediction of generated input directories

### DIFF
--- a/src/Common/Parsing/ProjectPredictionCollector.cs
+++ b/src/Common/Parsing/ProjectPredictionCollector.cs
@@ -73,9 +73,16 @@ internal sealed class ProjectPredictionCollector : IProjectPredictionCollector
             return;
         }
 
-        foreach (string normalizedFilePath in Directory.EnumerateFiles(normalizedDirPath, "*", SearchOption.TopDirectoryOnly))
+        string absoluteDirPath = Path.Combine(_repoRoot, normalizedDirPath);
+        if (!Directory.Exists(absoluteDirPath))
         {
-            AddInput(normalizedFilePath, predictorName);
+            // Ignore inputs to output directories which don't exist
+            return;
+        }
+
+        foreach (string filePath in Directory.EnumerateFiles(absoluteDirPath, "*", SearchOption.TopDirectoryOnly))
+        {
+            AddInputFile(filePath, projectInstance, predictorName);
         }
     }
 


### PR DESCRIPTION
If the predicted input directory does not exist yet, eg if it's an output directory, then the `Directory.EnumerateFiles` fails.

Furthermore, the path is normalized (enlistment-relative) and that path is enumerated, but the cwd may not be the repo root, so this is just plain incorrect.

This change fixes these by checking for directory existence and using the absolute path for the enumerate call.