### PR TITLE
Adjust to breaking change in FileAccessData ctor

### DIFF
--- a/tests/TestProject/Directory.Build.props
+++ b/tests/TestProject/Directory.Build.props
@@ -1,3 +1,6 @@
 <Project>
   <!-- Prevent the test projects from being affected by the root files -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This uses some fancy dynamic method shenanigans to adjust to https://github.com/dotnet/msbuild/pull/9615. This should be able to handle the MSBuild version we compile against as well as the new version.