### PR TITLE
Optimize RemoveLongPathPrefixes

### DIFF
--- a/src/Common/FileAccess/FileAccessRepository.cs
+++ b/src/Common/FileAccess/FileAccessRepository.cs
@@ -137,7 +137,7 @@ internal sealed class FileAccessRepository : IDisposable
 
                 uint processId = fileAccessData.ProcessId;
                 RequestedAccess requestedAccess = fileAccessData.RequestedAccess;
-                string path = PathHelper.RemoveLongPathPrefixes(fileAccessData.Path.AsSpan()).ToString();
+                string path = PathHelper.RemoveLongPathPrefixes(fileAccessData.Path);
                 uint error = fileAccessData.Error;
 
                 if (operation == ReportedFileOperation.Process)

--- a/src/Common/PathHelper.cs
+++ b/src/Common/PathHelper.cs
@@ -57,19 +57,19 @@ internal static class PathHelper
     /// \\?\ - removes the file name limit of 260 chars. It makes it 32735 (+ a null terminator)
     /// \??\ - this is a native Win32 FS path WinNt32
     /// </summary>
-    internal static ReadOnlySpan<char> RemoveLongPathPrefixes(ReadOnlySpan<char> absolutePath)
+    internal static string RemoveLongPathPrefixes(string absolutePath)
     {
-        ReadOnlySpan<char> pattern1 = @"\\?\".AsSpan();
-        ReadOnlySpan<char> pattern2 = @"\??\".AsSpan();
-
-        if (absolutePath.StartsWith(pattern1, StringComparison.OrdinalIgnoreCase))
+        if (absolutePath.Length < 4 || absolutePath[0] != '\\')
         {
-            return absolutePath.Slice(pattern1.Length);
+            return absolutePath;
         }
 
-        if (absolutePath.StartsWith(pattern2, StringComparison.OrdinalIgnoreCase))
+        // We already checked index 0
+        ReadOnlySpan<char> span = absolutePath.AsSpan(1, 3);
+        if (span.SequenceEqual(['\\', '?', '\\'])
+           || span.SequenceEqual(['?', '?', '\\']))
         {
-            return absolutePath.Slice(pattern2.Length);
+            return absolutePath.Substring(4);
         }
 
         return absolutePath;


### PR DESCRIPTION
Previously we were converting to a span, doing some operations, then converting back to a string. Usually the operation is a no-op though as most paths are not long paths, so this was allocating for no reason.

Beyond switching to just using a simple string, the optimized path short-circuits in the common case of not being a long path so is also much faster than the original logic anyway. In fact, at least for net8.0, BenchmarkDotNet says for the common case: "The method duration is indistinguishable from the empty method duration". So that's cool.