### PR TITLE
Copy package files from the package cache instead of ingesting them into the build cache

### DIFF
--- a/src/AzureBlobStorage/MSBuildCacheAzureBlobStoragePlugin.cs
+++ b/src/AzureBlobStorage/MSBuildCacheAzureBlobStoragePlugin.cs
@@ -39,7 +39,8 @@ public sealed class MSBuildCacheAzureBlobStoragePlugin : MSBuildCachePluginBase
         if (Settings == null
             || NodeContextRepository == null
             || FingerprintFactory == null
-            || ContentHasher == null)
+            || ContentHasher == null
+            || NugetPackageRoot == null)
         {
             throw new InvalidOperationException();
         }
@@ -91,6 +92,7 @@ public sealed class MSBuildCacheAzureBlobStoragePlugin : MSBuildCachePluginBase
             (remoteCache, remoteCacheSession, twoLevelConfig),
             ContentHasher,
             Settings.RepoRoot,
+            NugetPackageRoot,
             NodeContextRepository,
             GetFileRealizationMode,
             Settings.MaxConcurrentCacheContentOperations,

--- a/src/AzurePipelines/MSBuildCacheAzurePipelinesPlugin.cs
+++ b/src/AzurePipelines/MSBuildCacheAzurePipelinesPlugin.cs
@@ -28,7 +28,8 @@ public sealed class MSBuildCacheAzurePipelinesPlugin : MSBuildCachePluginBase
         if (Settings == null
             || NodeContextRepository == null
             || FingerprintFactory == null
-            || ContentHasher == null)
+            || ContentHasher == null
+            || NugetPackageRoot == null)
         {
             throw new InvalidOperationException();
         }
@@ -56,6 +57,7 @@ public sealed class MSBuildCacheAzurePipelinesPlugin : MSBuildCachePluginBase
             cacheLogger,
             Settings.CacheUniverse,
             Settings.RepoRoot,
+            NugetPackageRoot,
             NodeContextRepository,
             GetFileRealizationMode,
             Settings.MaxConcurrentCacheContentOperations,

--- a/src/AzurePipelines/PipelineCachingCacheClient.cs
+++ b/src/AzurePipelines/PipelineCachingCacheClient.cs
@@ -97,13 +97,14 @@ internal sealed class PipelineCachingCacheClient : CacheClient
         ILogger logger,
         string universe,
         string repoRoot,
+        string nugetPackageRoot,
         INodeContextRepository nodeContextRepository,
         Func<string, FileRealizationMode> getFileRealizationMode,
         int maxConcurrentCacheContentOperations,
         bool remoteCacheIsReadOnly,
         bool enableAsyncPublishing,
         bool enableAsyncMaterialization)
-        : base(rootContext, fingerprintFactory, hasher, repoRoot, nodeContextRepository, getFileRealizationMode, localCache, localCAS, maxConcurrentCacheContentOperations, enableAsyncPublishing, enableAsyncMaterialization)
+        : base(rootContext, fingerprintFactory, hasher, repoRoot, nugetPackageRoot, nodeContextRepository, getFileRealizationMode, localCache, localCAS, maxConcurrentCacheContentOperations, enableAsyncPublishing, enableAsyncMaterialization)
     {
         _remoteCacheIsReadOnly = remoteCacheIsReadOnly;
         _universe = $"pccc-{(int)hasher.Info.HashType}-{InternalSeed}-" + (string.IsNullOrEmpty(universe) ? "DEFAULT" : universe);

--- a/src/Common.Tests/NodeBuildResultTests.cs
+++ b/src/Common.Tests/NodeBuildResultTests.cs
@@ -45,6 +45,7 @@ public class NodeBuildResultTests
 
             NodeBuildResult nodeBuildResult = new(
                 maybeMixed,
+                new SortedDictionary<string, string>(),
                 new List<NodeTargetResult>(),
                 DateTime.UtcNow,
                 DateTime.UtcNow,

--- a/src/Common/Caching/CasCacheClient.cs
+++ b/src/Common/Caching/CasCacheClient.cs
@@ -47,12 +47,13 @@ public sealed class CasCacheClient : CacheClient
         (ICache cache, ICacheSession session, TwoLevelCacheConfiguration config)? remoteCache,
         IContentHasher hasher,
         string repoRoot,
+        string nugetPackageRoot,
         INodeContextRepository nodeContextRepository,
         Func<string, FileRealizationMode> getFileRealizationMode,
         int maxConcurrentCacheContentOperations,
         bool enableAsyncPublishing,
         bool enableAsyncMaterialization)
-        : base(rootContext, fingerprintFactory, hasher, repoRoot, nodeContextRepository, getFileRealizationMode, localCache, localCacheSession, maxConcurrentCacheContentOperations, enableAsyncPublishing, enableAsyncMaterialization)
+        : base(rootContext, fingerprintFactory, hasher, repoRoot, nugetPackageRoot, nodeContextRepository, getFileRealizationMode, localCache, localCacheSession, maxConcurrentCacheContentOperations, enableAsyncPublishing, enableAsyncMaterialization)
     {
         ICacheSession cacheSession;
         if (remoteCache == null)

--- a/src/Common/Fingerprinting/FingerprintFactory.cs
+++ b/src/Common/Fingerprinting/FingerprintFactory.cs
@@ -211,8 +211,8 @@ public sealed class FingerprintFactory : IFingerprintFactory
         foreach (string file in files)
         {
             string absoluteFilePath = pathsAreNormalized ? _pathNormalizer.Unnormalize(file) : file;
-            if (_pluginSettings.IgnoredInputPatterns.Count > 0
-                && !_pluginSettings.IgnoredInputPatterns.Any(pattern => pattern.IsMatch(absoluteFilePath)))
+            if (_pluginSettings.IgnoredInputPatterns.Count == 0
+                || !_pluginSettings.IgnoredInputPatterns.Any(pattern => pattern.IsMatch(absoluteFilePath)))
             {
                 string normalizedFilePath = pathsAreNormalized ? file : _pathNormalizer.Normalize(file);
 

--- a/src/Common/NodeBuildResult.cs
+++ b/src/Common/NodeBuildResult.cs
@@ -13,17 +13,19 @@ namespace Microsoft.MSBuildCache;
 
 public sealed class NodeBuildResult
 {
-    public const uint CurrentVersion = 0;
+    public const uint CurrentVersion = 1;
 
     [JsonConstructor]
     public NodeBuildResult(
         SortedDictionary<string, ContentHash> outputs,
+        SortedDictionary<string, string> packageFilesToCopy,
         IReadOnlyList<NodeTargetResult> targetResults,
         DateTime startTimeUtc,
         DateTime endTimeUtc,
         string? buildId)
     {
         Outputs = outputs;
+        PackageFilesToCopy = packageFilesToCopy;
         TargetResults = targetResults;
         StartTimeUtc = startTimeUtc;
         EndTimeUtc = endTimeUtc;
@@ -35,6 +37,9 @@ public sealed class NodeBuildResult
     [JsonConverter(typeof(SortedDictionaryConverter))]
     public SortedDictionary<string, ContentHash> Outputs { get; }
 
+    // Use a sorted dictionary so the JSON output is deterministically sorted and easier to compare build-to-build.
+    public SortedDictionary<string, string> PackageFilesToCopy { get; }
+
     public IReadOnlyList<NodeTargetResult> TargetResults { get; }
 
     public DateTime StartTimeUtc { get; }
@@ -43,7 +48,14 @@ public sealed class NodeBuildResult
 
     public string? BuildId { get; }
 
-    public static NodeBuildResult FromBuildResult(SortedDictionary<string, ContentHash> outputs, BuildResult buildResult, DateTime creationTimeUtc, DateTime endTimeUtc, string? buildId, PathNormalizer pathNormalizer)
+    public static NodeBuildResult FromBuildResult(
+        SortedDictionary<string, ContentHash> outputs,
+        SortedDictionary<string, string> packageFilesToCopy,
+        BuildResult buildResult,
+        DateTime creationTimeUtc,
+        DateTime endTimeUtc,
+        string? buildId,
+        PathNormalizer pathNormalizer)
     {
         List<NodeTargetResult> targetResults = new(buildResult.ResultsByTarget.Count);
         foreach (KeyValuePair<string, TargetResult> kvp in buildResult.ResultsByTarget)
@@ -51,7 +63,7 @@ public sealed class NodeBuildResult
             targetResults.Add(NodeTargetResult.FromTargetResult(kvp.Key, kvp.Value, pathNormalizer));
         }
 
-        return new NodeBuildResult(outputs, targetResults, creationTimeUtc, endTimeUtc, buildId);
+        return new NodeBuildResult(outputs, packageFilesToCopy, targetResults, creationTimeUtc, endTimeUtc, buildId);
     }
 
     public CacheResult ToCacheResult(PathNormalizer pathNormalizer)

--- a/src/Local/MSBuildCacheLocalPlugin.cs
+++ b/src/Local/MSBuildCacheLocalPlugin.cs
@@ -27,7 +27,8 @@ public sealed class MSBuildCacheLocalPlugin : MSBuildCachePluginBase
         if (Settings == null
             || NodeContextRepository == null
             || FingerprintFactory == null
-            || ContentHasher == null)
+            || ContentHasher == null
+            || NugetPackageRoot == null)
         {
             throw new InvalidOperationException();
         }
@@ -58,6 +59,7 @@ public sealed class MSBuildCacheLocalPlugin : MSBuildCachePluginBase
             remoteCache: null,
             ContentHasher,
             Settings.RepoRoot,
+            NugetPackageRoot,
             NodeContextRepository,
             GetFileRealizationMode,
             Settings.MaxConcurrentCacheContentOperations,

--- a/tests/TestProject/TestProject.csproj
+++ b/tests/TestProject/TestProject.csproj
@@ -10,6 +10,9 @@
   <ItemGroup>
     <PackageReference Include="$(MSBuildCachePackage)" Version="*-*" />
     <PackageReference Include="Microsoft.MSBuildCache.SharedCompilation" Version="*-*" />
+
+    <!-- Ensure package content copying code is exercised. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -40,8 +40,9 @@ function Run-Test {
     Write-Host "[$TestName] Starting test"
 
     Write-Host "[$TestName] Cleaning"
-    Remove-Item -Path "$ProjectDir\obj" -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Item -Path "$ProjectDir\bin" -Recurse -Force -ErrorAction SilentlyContinue
+    Push-Location $ProjectDir
+    & git clean -fdx
+    Pop-Location
 
     Write-Host "[$TestName] Building"
     $ProcessOptions = @{


### PR DESCRIPTION
A non-trivial part of builds is simply copying content from packages and there's no need to duplicate that content into the build cache when the package cache should already contain the files. As packages are expected to be immutable, this should be a safe operation.

In my test repo with 100% cache hits, this saves ~50% of the build time (pulling everything from blob storage cache) and cuts the remote storage by about ~50% as well. Note that this test was on residential internet, so that 50% build time savings may not be completely representative if the CI build agents have a super fast connection to the storage, but the storage cost savings should be.

This change does a couple things:
* When processing a node in `HandleProjectFinished` ("cache add")
  * While enumerating the inputs, keep track of the ones under the nuget package root, hashing as necessary. Note that these files are hashed anyway when constructing either the weak or strong fingerprints, so this is not any additional hashing work.
  * While creating the `NodeBuildResult`, create a collection called `PackageFilesToCopy` which is the set of outputs whose hash matches a package input. The `PackageFilesToCopy` collection's keys are the enlistment-relative output paths and the values are the package root relative paths of the source file. This collection is added as part of the `NodeBuildResult`.
  * While adding content files to the cache, avoid adding any files listed in `PackageFilesToCopy`
* When fetching a node from the cache, specifically the content ("cache get")
  * If an output file is listed in `PackageFilesToCopy`, avoid asking the cache for it in favor of simply copying it from the package root. Note that CoW is supported for this operation.