### PR TITLE
Use filtered global properties for node ids

### DIFF
--- a/src/Common/Fingerprinting/FingerprintFactory.cs
+++ b/src/Common/Fingerprinting/FingerprintFactory.cs
@@ -86,7 +86,7 @@ public sealed class FingerprintFactory : IFingerprintFactory
                     CreateFingerprintEntry(nodeContext.ProjectFileRelativePath)
                 };
 
-                foreach (KeyValuePair<string, string> property in nodeContext.GlobalProperties)
+                foreach (KeyValuePair<string, string> property in nodeContext.FilteredGlobalProperties)
                 {
                     entries.Add(CreateFingerprintEntry($"{property.Key}={property.Value}"));
                 }

--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -298,7 +298,7 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
             }
 
             NodeDescriptor nodeDescriptor = _nodeDescriptorFactory.Create(node.ProjectInstance);
-            NodeContext nodeContext = new(Settings.LogDirectory, node, parserInfo.ProjectFileRelativePath, nodeDescriptor.GlobalProperties, inputs, targetNames);
+            NodeContext nodeContext = new(Settings.LogDirectory, node, parserInfo.ProjectFileRelativePath, nodeDescriptor.FilteredGlobalProperties, inputs, targetNames);
 
             dumpParserInfoTasks.Add(Task.Run(() => DumpParserInfoAsync(logger, nodeContext, parserInfo), cancellationToken));
             nodeContexts.Add(nodeDescriptor, nodeContext);
@@ -733,7 +733,7 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
                 jsonWriter.WriteString("projectFileRelativePath", nodeContext.ProjectFileRelativePath);
 
                 jsonWriter.WriteStartObject("globalProperties");
-                foreach (KeyValuePair<string, string> kvp in nodeContext.GlobalProperties)
+                foreach (KeyValuePair<string, string> kvp in nodeContext.FilteredGlobalProperties)
                 {
                     jsonWriter.WriteString(kvp.Key, kvp.Value);
                 }

--- a/src/Common/NodeContext.cs
+++ b/src/Common/NodeContext.cs
@@ -22,15 +22,15 @@ public sealed class NodeContext
         string baseLogDirectory,
         ProjectGraphNode node,
         string projectFileRelativePath,
-        IReadOnlyDictionary<string, string> globalProperties,
+        IReadOnlyDictionary<string, string> filteredGlobalProperties,
         IReadOnlyList<string> inputs,
         HashSet<string> targetNames)
     {
-        Id = GenerateId(projectFileRelativePath, globalProperties);
+        Id = GenerateId(projectFileRelativePath, filteredGlobalProperties);
         _logDirectory = Path.Combine(baseLogDirectory, Id);
         Node = node;
         ProjectFileRelativePath = projectFileRelativePath;
-        GlobalProperties = globalProperties;
+        FilteredGlobalProperties = filteredGlobalProperties;
         Inputs = inputs;
         TargetNames = targetNames;
     }
@@ -56,7 +56,7 @@ public sealed class NodeContext
 
     public string ProjectFileRelativePath { get; }
 
-    public IReadOnlyDictionary<string, string> GlobalProperties { get; }
+    public IReadOnlyDictionary<string, string> FilteredGlobalProperties { get; }
 
     public IReadOnlyList<string> Inputs { get; }
 
@@ -85,13 +85,13 @@ public sealed class NodeContext
     /// <summary>
     /// Generate a stable Id which we can use for sorting and comparison purposes across builds.
     /// </summary>
-    private static string GenerateId(string projectFileRelativePath, IReadOnlyDictionary<string, string> globalProperties)
+    private static string GenerateId(string projectFileRelativePath, IReadOnlyDictionary<string, string> filteredGlobalProperties)
     {
         // In practice, the dictionary we're given is SortedDictionary<string, string>, so try casting.
-        if (globalProperties is not SortedDictionary<string, string> sortedProperties)
+        if (filteredGlobalProperties is not SortedDictionary<string, string> sortedProperties)
         {
             sortedProperties = new(StringComparer.OrdinalIgnoreCase);
-            foreach (KeyValuePair<string, string> kvp in globalProperties)
+            foreach (KeyValuePair<string, string> kvp in filteredGlobalProperties)
             {
                 sortedProperties.Add(kvp.Key, kvp.Value);
             }

--- a/src/Common/NodeDescriptor.cs
+++ b/src/Common/NodeDescriptor.cs
@@ -10,18 +10,18 @@ public readonly struct NodeDescriptor : IEquatable<NodeDescriptor>
 {
     private readonly string _projectFullPath;
 
-    private readonly SortedDictionary<string, string> _globalProperties;
+    private readonly SortedDictionary<string, string> _filteredGlobalProperties;
 
-    public NodeDescriptor(string projectFullPath, SortedDictionary<string, string> globalProperties)
+    public NodeDescriptor(string projectFullPath, SortedDictionary<string, string> filteredGlobalProperties)
     {
         _projectFullPath = projectFullPath;
-        _globalProperties = globalProperties;
+        _filteredGlobalProperties = filteredGlobalProperties;
     }
 
     /// <summary>
     /// Sorted by StringComparison.OrdinalIgnoreCase.
     /// </summary>
-    public IReadOnlyDictionary<string, string> GlobalProperties => _globalProperties;
+    public IReadOnlyDictionary<string, string> FilteredGlobalProperties => _filteredGlobalProperties;
 
     public bool Equals(NodeDescriptor other)
     {
@@ -30,14 +30,14 @@ public readonly struct NodeDescriptor : IEquatable<NodeDescriptor>
             return false;
         }
 
-        if (_globalProperties.Count != other._globalProperties.Count)
+        if (_filteredGlobalProperties.Count != other._filteredGlobalProperties.Count)
         {
             return false;
         }
 
-        foreach (KeyValuePair<string, string> kvp in _globalProperties)
+        foreach (KeyValuePair<string, string> kvp in _filteredGlobalProperties)
         {
-            if (!other._globalProperties.TryGetValue(kvp.Key, out string? otherValue))
+            if (!other._filteredGlobalProperties.TryGetValue(kvp.Key, out string? otherValue))
             {
                 return false;
             }
@@ -62,7 +62,7 @@ public readonly struct NodeDescriptor : IEquatable<NodeDescriptor>
         HashCode hashCode = new();
         hashCode.Add(_projectFullPath, StringComparer.OrdinalIgnoreCase);
 
-        foreach (KeyValuePair<string, string> kvp in _globalProperties)
+        foreach (KeyValuePair<string, string> kvp in _filteredGlobalProperties)
         {
             hashCode.Add(kvp.Key, StringComparer.OrdinalIgnoreCase);
             hashCode.Add(kvp.Value, StringComparer.OrdinalIgnoreCase);

--- a/src/Common/NodeDescriptorFactory.cs
+++ b/src/Common/NodeDescriptorFactory.cs
@@ -29,7 +29,7 @@ public sealed class NodeDescriptorFactory
     {
         // Sort to ensure a consistent hash for equivalent sets of properties.
         // This allocates with the assumption that the hash code is used multiple times.
-        SortedDictionary<string, string> sortedGlobalProperties = new(StringComparer.OrdinalIgnoreCase);
+        SortedDictionary<string, string> filteredGlobalProperties = new(StringComparer.OrdinalIgnoreCase);
         foreach (KeyValuePair<string, string> kvp in globalProperties)
         {
             if (kvp.Key.StartsWith(MSBuildProjectInstancePrefix, StringComparison.OrdinalIgnoreCase))
@@ -42,10 +42,10 @@ public sealed class NodeDescriptorFactory
                 continue;
             }
 
-            sortedGlobalProperties.Add(kvp.Key, kvp.Value);
+            filteredGlobalProperties.Add(kvp.Key, kvp.Value);
         }
 
-        return new NodeDescriptor(projectFullPath, sortedGlobalProperties);
+        return new NodeDescriptor(projectFullPath, filteredGlobalProperties);
     }
 
     // Adapts IDictionary to IReadOnlyDictionary


### PR DESCRIPTION
The current behavior uses the full set of global properties to generate the ids, which may be different from build to build since it may contain `MSBuildCacheLogDirectory` for example. We filter some global properties when fingerprinting, so we should use those same filtered global properties for the ids.

This usually doesn't really matter, but there are two case which it does. The first is that it just makes diffing across builds more difficult when they don't line up. More importantly though, this can cause cache misses for outer builds where the (dependent) inner builds end up sorting differently based on the id differences. eg if a multitargeting project targeting net8.0 and net472, the fingerprint for the outer build would contain both inner builds as dependencies and those obviously have the same project names as each other so only differ by id.