### PR TITLE
Consume requested targets when constructing the graph

### DIFF
--- a/.azuredevops/pipelines/pr-ci.yml
+++ b/.azuredevops/pipelines/pr-ci.yml
@@ -57,11 +57,12 @@ jobs:
 
   - checkout: self
 
-  - task: Cache@2
-    displayName: Cache Visual Studio
-    inputs:
-      key: '"vs-release" | "$(Agent.OS)"'
-      path: $(VsInstallDir)
+  # Avoiding Caching VS for now as the installer command we're using doesn't work for upgrades
+  # - task: Cache@2
+  #   displayName: Cache Visual Studio
+  #   inputs:
+  #     key: '"vs-release" | "$(Agent.OS)"'
+  #     path: $(VsInstallDir)
 
   - script: |
       del %TEMP%\vs_buildtools.exe
@@ -77,6 +78,10 @@ jobs:
       echo VS installer exit code: %ERRORLEVEL%
 
       del %TEMP%\vs_buildtools.exe
+
+      echo Copying installer logs
+      mkdir "$(LogDirectory)\VSSetup"
+      move "%TEMP%\dd_*" "$(LogDirectory)\VSSetup\"
 
       echo Current MSBuild version:
       "$(MSBuildPath)" --version
@@ -105,11 +110,12 @@ jobs:
 
   - checkout: self
 
-  - task: Cache@2
-    displayName: Cache Visual Studio
-    inputs:
-      key: '"vs-pre" | "$(Agent.OS)"'
-      path: $(VsInstallDir)
+  # Avoiding Caching VS for now as the installer command we're using doesn't work for upgrades
+  # - task: Cache@2
+  #   displayName: Cache Visual Studio
+  #   inputs:
+  #     key: '"vs-pre" | "$(Agent.OS)"'
+  #     path: $(VsInstallDir)
 
   - script: |
       del %TEMP%\vs_buildtools.exe
@@ -125,6 +131,10 @@ jobs:
       echo VS installer exit code: %ERRORLEVEL%
 
       del %TEMP%\vs_buildtools.exe
+
+      echo Copying installer logs
+      mkdir "$(LogDirectory)\VSSetup"
+      move "%TEMP%\dd_*" "$(LogDirectory)\VSSetup\"
 
       echo Current MSBuild version:
       "$(MSBuildPath)" --version

--- a/.azuredevops/pipelines/templates/variables.yml
+++ b/.azuredevops/pipelines/templates/variables.yml
@@ -5,3 +5,4 @@ variables:
   ArtifactsDirectory: $(Build.ArtifactStagingDirectory)\artifacts
   # https://github.com/microsoft/azure-pipelines-agent/pull/4077
   VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC: 5
+  EnablePipelineCache: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## Setup
 
-It is assumed that you are using VS v17.8 or later.
+It is assumed that you are using VS v17.9 or later.
 
 ## Building
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <ArtifactsPackageVersion>19.232.34508-buildid25403274</ArtifactsPackageVersion>
     <BuildXLPackageVersion>0.1.0-20240121.1</BuildXLPackageVersion>
-    <MSBuildPackageVersion>17.8.3</MSBuildPackageVersion>
+    <MSBuildPackageVersion>17.9.5</MSBuildPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
     <PackageVersion Include="DotNet.Glob" Version="2.0.3" />
     <PackageVersion Include="ILRepack" Version="2.0.27" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageVersion Include="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
@@ -39,14 +39,14 @@
     <PackageVersion Include="protobuf-net" Version="3.2.26" />
     <PackageVersion Include="protobuf-net.Core" Version="3.2.26" />
     <PackageVersion Include="protobuf-net.Grpc" Version="1.1.1" />
-    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
     <PackageVersion Include="System.Private.ServiceModel" Version="4.10.3" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="7.0.0" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
-    <PackageVersion Include="System.Threading.Channels" Version="7.0.0" />
-    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
+    <PackageVersion Include="System.Threading.Channels" Version="8.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />

--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -273,8 +273,8 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
         Parser parser = new(logger, _repoRoot);
         IReadOnlyDictionary<ProjectGraphNode, ParserInfo> parserInfoForNodes = parser.Parse(graph);
 
-        // TODO: MSBuild should give this to us via CacheContext
-        var entryProjectTargets = Array.Empty<string>();
+        // In practice, the underlying type of the IReadOnlyCollection is a ICollection<string> so attempt to cast first. We're not mutating the collection so still abiding by the readonly-ness.
+        ICollection<string> entryProjectTargets = context.RequestedTargets as ICollection<string> ?? new List<string>(context.RequestedTargets);
         IReadOnlyDictionary<ProjectGraphNode, ImmutableList<string>> targetListPerNode = graph.GetTargetLists(entryProjectTargets);
 
         Dictionary<NodeDescriptor, NodeContext> nodeContexts = new(parserInfoForNodes.Count);

--- a/src/SharedCompilation/VBCSCompilerReporter.cs
+++ b/src/SharedCompilation/VBCSCompilerReporter.cs
@@ -9,8 +9,6 @@ using System.Diagnostics;
 #endif
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
 using Microsoft.Build.Experimental.FileAccess;
 using Microsoft.Build.Framework;
 using Microsoft.CodeAnalysis;
@@ -223,24 +221,9 @@ internal static class VBCSCompilerReporter
     {
         private delegate void ReportFileAccessFn(FileAccessData fileAccessData);
 
-        private delegate FileAccessData CreateFileAccessFn(
-            ReportedFileOperation operation,
-            RequestedAccess requestedAccess,
-            uint processId,
-            uint id,
-            uint correlationId,
-            uint error,
-            DesiredAccess desiredAccess,
-            FlagsAndAttributes flagsAndAttributes,
-            string path,
-            string processArgs,
-            bool isAnAugmentedFileAccess);
-
         private readonly string _basePath;
 
         private readonly ReportFileAccessFn _reportFileAccess;
-
-        private readonly CreateFileAccessFn _createFileAccess;
 
         private static readonly uint ProcessId = (uint)
 #if NET472
@@ -257,57 +240,6 @@ internal static class VBCSCompilerReporter
             // Use reflection to get the ReportFileAccess method since it's not exposed.
             // TODO: Once there is a proper API for this, use it.
             _reportFileAccess = (ReportFileAccessFn)Delegate.CreateDelegate(typeof(ReportFileAccessFn), engineServices, "ReportFileAccess");
-
-            ConstructorInfo fileAccessDataCtor = typeof(FileAccessData).GetConstructors()[0];
-            ParameterInfo[] fileAccessDataCtorParams = fileAccessDataCtor.GetParameters();
-            if (fileAccessDataCtorParams.Length == 9)
-            {
-                // This is the one we compiled against so just use it.
-                _createFileAccess = (
-                    ReportedFileOperation operation,
-                    RequestedAccess requestedAccess,
-                    uint processId,
-                    uint id,
-                    uint correlationId,
-                    uint error,
-                    DesiredAccess desiredAccess,
-                    FlagsAndAttributes flagsAndAttributes,
-                    string path,
-                    string processArgs,
-                    bool isAnAugmentedFileAccess)
-                    => new FileAccessData(operation, requestedAccess, processId, error, desiredAccess, flagsAndAttributes, path, processArgs, isAnAugmentedFileAccess);
-            }
-            else if (fileAccessDataCtorParams.Length == 11)
-            {
-                // Adjust to a breaking change made in MSBuild to the FileAccessData ctor. See: https://github.com/dotnet/msbuild/pull/9615
-                // Create a dynamic method which basically just invokes the ctor with all the params from the CreateFileAccessFn delegate.
-                DynamicMethod dynamicMethod = new(
-                    name: string.Empty,
-                    returnType: typeof(FileAccessData),
-                    parameterTypes: fileAccessDataCtorParams.Select(param => param.ParameterType).ToArray(),
-                    owner: typeof(FileAccessData));
-
-                ILGenerator il = dynamicMethod.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldarg_1);
-                il.Emit(OpCodes.Ldarg_2);
-                il.Emit(OpCodes.Ldarg_3);
-                il.Emit(OpCodes.Ldarg_S, 4);
-                il.Emit(OpCodes.Ldarg_S, 5);
-                il.Emit(OpCodes.Ldarg_S, 6);
-                il.Emit(OpCodes.Ldarg_S, 7);
-                il.Emit(OpCodes.Ldarg_S, 8);
-                il.Emit(OpCodes.Ldarg_S, 9);
-                il.Emit(OpCodes.Ldarg_S, 10);
-                il.Emit(OpCodes.Newobj, fileAccessDataCtor);
-                il.Emit(OpCodes.Ret);
-
-                _createFileAccess = (CreateFileAccessFn)dynamicMethod.CreateDelegate(typeof(CreateFileAccessFn));
-            }
-            else
-            {
-                throw new MissingMethodException("Could not find supported constructor for FileAccessData");
-            }
         }
 
         public void RegisterOutput(string? filePath) => RegisterAccess(filePath, RequestedAccess.Write, DesiredAccess.GENERIC_WRITE);
@@ -338,7 +270,7 @@ internal static class VBCSCompilerReporter
                 return;
             }
 
-            FileAccessData fileAccessData = _createFileAccess(
+            FileAccessData fileAccessData = new(
                 ReportedFileOperation.CreateFile,
                 requestedAccess,
                 ProcessId,


### PR DESCRIPTION
This consumes the requested targets so that scenarios using the non-default targets (eg `msbuild /t:Build;Test`) can be properly supported.

Related MSBuild PR: https://github.com/dotnet/msbuild/pull/9569

Note that this sets a new minimum supported MSBuild versions as 17.9, which also allowed cleanup of some compat-related code.