### PR TITLE
Add the Visual Studio version, if available, to the cache key

### DIFF
--- a/src/Common/Fingerprinting/FingerprintFactory.cs
+++ b/src/Common/Fingerprinting/FingerprintFactory.cs
@@ -73,6 +73,13 @@ public sealed class FingerprintFactory : IFingerprintFactory
         AddSettingToFingerprint(pluginSettings.AllowFileAccessAfterProjectFinishFilePatterns, nameof(pluginSettings.AllowFileAccessAfterProjectFinishFilePatterns));
         AddSettingToFingerprint(pluginSettings.AllowFileAccessAfterProjectFinishProcessPatterns, nameof(pluginSettings.AllowFileAccessAfterProjectFinishProcessPatterns));
         AddSettingToFingerprint(pluginSettings.AllowProcessCloseAfterProjectFinishProcessPatterns, nameof(pluginSettings.AllowProcessCloseAfterProjectFinishProcessPatterns));
+
+        // Use the Visual Studio version as part of the cache key since different versions of VS might have different build logic and C++ compilers of differing versions are incompatible to each other.
+        string? visualStudioVersion = Environment.GetEnvironmentVariable("VSCMD_VER");
+        if (!string.IsNullOrEmpty(visualStudioVersion))
+        {
+            _pluginSettingsFingerprintEntries.Add(CreateFingerprintEntry($"Visual Studio Version: {visualStudioVersion}"));
+        }
     }
 
     public async Task<Fingerprint?> GetWeakFingerprintAsync(NodeContext nodeContext)


### PR DESCRIPTION
This should address issues like this:

> LINK(0,0): Error C1047: The object or library file 'D:\a\_work\1\s\x64\Release\spdlog.lib' was created by a different version of the compiler than other objects like 'x64\Release\dllmain.obj'; rebuild all objects and libraries with the same compiler