### PR TITLE
Add disabled NI task on pipeline builds

### DIFF
--- a/.azuredevops/pipelines/official.yml
+++ b/.azuredevops/pipelines/official.yml
@@ -64,6 +64,9 @@ extends:
             targetPath: $(ArtifactsDirectory)
             artifactName: artifacts
         steps:
+        - template: templates\network-isolation.yml
+          parameters:
+            NetworkIsolationMode: $(NetworkIsolationMode)
         - task: PowerShell@2
           displayName: 'Update SignType, Build Number, and Add Build Tag for tagged commits'
           condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))

--- a/.azuredevops/pipelines/official.yml
+++ b/.azuredevops/pipelines/official.yml
@@ -4,6 +4,10 @@ resources:
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
     ref: refs/tags/release
+parameters:
+- name: NetworkIsolationMode
+  type: string
+  default: Disabled
 variables:
 - template: /.azuredevops/pipelines/templates/variables.yml@self
 - name: SignType

--- a/.azuredevops/pipelines/official.yml
+++ b/.azuredevops/pipelines/official.yml
@@ -6,8 +6,13 @@ resources:
     ref: refs/tags/release
 parameters:
 - name: NetworkIsolationMode
+  displayName: 'Network Isolation Mode'
   type: string
   default: Disabled
+  values:
+  - Disabled
+  - Audit
+  - Enforce
 variables:
 - template: /.azuredevops/pipelines/templates/variables.yml@self
 - name: SignType
@@ -70,7 +75,7 @@ extends:
         steps:
         - template: templates\network-isolation.yml
           parameters:
-            NetworkIsolationMode: $(NetworkIsolationMode)
+            NetworkIsolationMode: ${{ parameters.NetworkIsolationMode }}
         - task: PowerShell@2
           displayName: 'Update SignType, Build Number, and Add Build Tag for tagged commits'
           condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))

--- a/.azuredevops/pipelines/pr-ci.yml
+++ b/.azuredevops/pipelines/pr-ci.yml
@@ -1,6 +1,11 @@
 variables:
 - template: templates\variables.yml
 
+parameters:
+- name: NetworkIsolationMode
+  type: string
+  default: Disabled
+
 schedules:
 - cron: '0 0 * * *'
   displayName: Daily midnight build

--- a/.azuredevops/pipelines/pr-ci.yml
+++ b/.azuredevops/pipelines/pr-ci.yml
@@ -33,6 +33,10 @@ jobs:
 - job: Build
   displayName: Build and Test
   steps:
+  - template: templates\network-isolation.yml
+    parameters:
+      NetworkIsolationMode: $(NetworkIsolationMode)
+
   - checkout: self
     # Fetch all history for versioning
     fetchDepth: 0
@@ -73,6 +77,10 @@ jobs:
     VsInstallDir: $(Build.ArtifactStagingDirectory)\vs
     MSBuildPath: $(VsInstallDir)\MSBuild\Current\Bin\amd64\MSBuild.exe
   steps:
+  - template: templates\network-isolation.yml
+    parameters:
+      NetworkIsolationMode: $(NetworkIsolationMode)
+
   - download: current
     displayName: 'Download Build Artifacts'
     artifact: artifacts
@@ -126,6 +134,10 @@ jobs:
     VsInstallDir: $(Build.ArtifactStagingDirectory)\vs
     MSBuildPath: $(VsInstallDir)\MSBuild\Current\Bin\amd64\MSBuild.exe
   steps:
+  - template: templates\network-isolation.yml
+    parameters:
+      NetworkIsolationMode: $(NetworkIsolationMode)
+
   - download: current
     displayName: 'Download Build Artifacts'
     artifact: artifacts
@@ -178,6 +190,10 @@ jobs:
   variables:
     MSBuildPath: $(Build.SourcesDirectory)\msbuild\artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\amd64\MSBuild.exe
   steps:
+  - template: templates\network-isolation.yml
+    parameters:
+      NetworkIsolationMode: $(NetworkIsolationMode)
+
   - download: current
     displayName: 'Download Build Artifacts'
     artifact: artifacts

--- a/.azuredevops/pipelines/pr-ci.yml
+++ b/.azuredevops/pipelines/pr-ci.yml
@@ -3,8 +3,13 @@ variables:
 
 parameters:
 - name: NetworkIsolationMode
+  displayName: 'Network Isolation Mode'
   type: string
   default: Disabled
+  values:
+  - Disabled
+  - Audit
+  - Enforce
 
 schedules:
 - cron: '0 0 * * *'
@@ -40,7 +45,7 @@ jobs:
   steps:
   - template: templates\network-isolation.yml
     parameters:
-      NetworkIsolationMode: $(NetworkIsolationMode)
+      NetworkIsolationMode: ${{ parameters.NetworkIsolationMode }}
 
   - checkout: self
     # Fetch all history for versioning
@@ -84,7 +89,7 @@ jobs:
   steps:
   - template: templates\network-isolation.yml
     parameters:
-      NetworkIsolationMode: $(NetworkIsolationMode)
+      NetworkIsolationMode: ${{ parameters.NetworkIsolationMode }}
 
   - download: current
     displayName: 'Download Build Artifacts'
@@ -141,7 +146,7 @@ jobs:
   steps:
   - template: templates\network-isolation.yml
     parameters:
-      NetworkIsolationMode: $(NetworkIsolationMode)
+      NetworkIsolationMode: ${{ parameters.NetworkIsolationMode }}
 
   - download: current
     displayName: 'Download Build Artifacts'
@@ -197,7 +202,7 @@ jobs:
   steps:
   - template: templates\network-isolation.yml
     parameters:
-      NetworkIsolationMode: $(NetworkIsolationMode)
+      NetworkIsolationMode: ${{ parameters.NetworkIsolationMode }}
 
   - download: current
     displayName: 'Download Build Artifacts'

--- a/.azuredevops/pipelines/templates/network-isolation.yml
+++ b/.azuredevops/pipelines/templates/network-isolation.yml
@@ -1,0 +1,11 @@
+parameters:
+- name: NetworkIsolationMode
+  type: string
+  default: Disabled
+
+steps:
+- task: tse-cloudbuild.1es-networkisolation-tasks-test.1D5CFFFE-4332-4DE5-8457-7657C0B89BB9.1ESNetworkIsolation@1
+  displayName: Apply FW
+  condition: ne(variables['NetworkIsolationMode'], 'Disabled')
+  inputs:
+    networkIsolationMode: $(NetworkIsolationMode)

--- a/.azuredevops/pipelines/templates/network-isolation.yml
+++ b/.azuredevops/pipelines/templates/network-isolation.yml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
 - task: tse-cloudbuild.1es-networkisolation-tasks.661EE24A-9364-4A3B-A725-3CBEB6F35E4B.1ESNetworkIsolation@1
-  displayName: Apply FW
+  displayName: Network Isolation
   condition: ne(variables['NetworkIsolationMode'], 'Disabled')
   inputs:
     networkIsolationMode: $(NetworkIsolationMode)

--- a/.azuredevops/pipelines/templates/network-isolation.yml
+++ b/.azuredevops/pipelines/templates/network-isolation.yml
@@ -4,7 +4,7 @@ parameters:
   default: Disabled
 
 steps:
-- task: tse-cloudbuild.1es-networkisolation-tasks-test.1D5CFFFE-4332-4DE5-8457-7657C0B89BB9.1ESNetworkIsolation@1
+- task: tse-cloudbuild.1es-networkisolation-tasks.661EE24A-9364-4A3B-A725-3CBEB6F35E4B.1ESNetworkIsolation@1
   displayName: Apply FW
   condition: ne(variables['NetworkIsolationMode'], 'Disabled')
   inputs:

--- a/.azuredevops/pipelines/templates/network-isolation.yml
+++ b/.azuredevops/pipelines/templates/network-isolation.yml
@@ -6,6 +6,6 @@ parameters:
 steps:
 - task: tse-cloudbuild.1es-networkisolation-tasks.661EE24A-9364-4A3B-A725-3CBEB6F35E4B.1ESNetworkIsolation@1
   displayName: Network Isolation
-  condition: ne(${{ parameters.NetworkIsolationMode }}, 'Disabled')
+  condition: ne('${{ parameters.NetworkIsolationMode }}', 'Disabled')
   inputs:
     networkIsolationMode: ${{ parameters.NetworkIsolationMode }}

--- a/.azuredevops/pipelines/templates/network-isolation.yml
+++ b/.azuredevops/pipelines/templates/network-isolation.yml
@@ -6,6 +6,6 @@ parameters:
 steps:
 - task: tse-cloudbuild.1es-networkisolation-tasks.661EE24A-9364-4A3B-A725-3CBEB6F35E4B.1ESNetworkIsolation@1
   displayName: Network Isolation
-  condition: ne(variables['NetworkIsolationMode'], 'Disabled')
+  condition: ne(${{ parameters.NetworkIsolationMode }}, 'Disabled')
   inputs:
-    networkIsolationMode: $(NetworkIsolationMode)
+    networkIsolationMode: ${{ parameters.NetworkIsolationMode }}

--- a/.azuredevops/pipelines/templates/variables.yml
+++ b/.azuredevops/pipelines/templates/variables.yml
@@ -6,3 +6,4 @@ variables:
   # https://github.com/microsoft/azure-pipelines-agent/pull/4077
   VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC: 5
   EnablePipelineCache: true
+  NetworkIsolationMode: Disabled

--- a/.azuredevops/pipelines/templates/variables.yml
+++ b/.azuredevops/pipelines/templates/variables.yml
@@ -6,4 +6,3 @@ variables:
   # https://github.com/microsoft/azure-pipelines-agent/pull/4077
   VSO_DEDUP_REDIRECT_TIMEOUT_IN_SEC: 5
   EnablePipelineCache: true
-  NetworkIsolationMode: Disabled


### PR DESCRIPTION
The task will default to be disabled for the time being and avoid breaking the build if something goes wrong but can be enabled in Audit or Enforce mode on manual pipeline runs.