### PR TITLE
Add VCToolsVersion and NETCoreSdkVersion properties to fingerprints

### DIFF
--- a/src/Common/Fingerprinting/FingerprintFactory.cs
+++ b/src/Common/Fingerprinting/FingerprintFactory.cs
@@ -96,6 +96,20 @@ public sealed class FingerprintFactory : IFingerprintFactory
                 string targetList = string.Join(", ", nodeContext.TargetNames.OrderBy(target => target, StringComparer.OrdinalIgnoreCase));
                 entries.Add(CreateFingerprintEntry($"Targets: {targetList}"));
 
+                // If the VC toolchain changes, the node should rebuild.
+                string vcToolsVersion = nodeContext.Node.ProjectInstance.GetPropertyValue("VCToolsVersion");
+                if (!string.IsNullOrEmpty(vcToolsVersion))
+                {
+                    entries.Add(CreateFingerprintEntry($"VCToolsVersion: {vcToolsVersion}"));
+                }
+
+                // If the .NET SDK changes, the node should rebuild.
+                string dotnetSdkVersion = nodeContext.Node.ProjectInstance.GetPropertyValue("NETCoreSdkVersion");
+                if (!string.IsNullOrEmpty(dotnetSdkVersion))
+                {
+                    entries.Add(CreateFingerprintEntry($"DotnetSdkVersion: {dotnetSdkVersion}"));
+                }
+
                 // Add predicted inputs
                 await SortAndAddInputFileHashesAsync(entries, nodeContext.Inputs, pathsAreNormalized: false);
 


### PR DESCRIPTION
Add VCToolsVersion and NETCoreSdkVersion properties to fingerprints

These are to help with the situation of build tooling like VS updating and some projects coming from cache from the old version while newer projects are rebuilt.

For `VCToolsVersion`, the linker is not able to handle obj files which were compiled with different versions of the compiler:

> LINK(0,0): Error C1047: The object or library file 'D:\a\_work\1\s\x64\Release\spdlog.lib' was created by a different version of the compiler than other objects like 'x64\Release\dllmain.obj'; rebuild all objects and libraries with the same compiler

For `NETCoreSdkVersion`, upgrading the SDK may upgrade the bundled runtime runtime. This can lead to an older runtime being copied, which fails as it's usually no longer installed, not to mention being undesirable to use an older patch version of the runtime):

> C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets(5270,5): Error MSB3030: MSB3030: Could not copy the file "C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Host.win-x64\8.0.6\runtimes\win-x64\native\Ijwhost.dll" because it was not found.