### PR TITLE
AzureBlobStorage: Add interactive and MI auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,16 @@ This implementation uses [Azure Blob Storage](https://azure.microsoft.com/en-us/
 > [!WARNING]
 > This implementation does not yet have a robust security model. All builds using this will need write access to the storage resource, so for example an external contributor could send a PR which would write/overwrite arbitrary content which could then be used by CI builds. Builds using this plugin must be restricted to trusted team members. Use at your own risk.
 
-The connection string to the blob storage account must be provided in the `MSBUILDCACHE_CONNECTIONSTRING` environment variable. This connection string needs both read and write access to the resource.
+These settings are available in addition to the [Common Settings](#common-settings):
+
+| MSBuild Property Name | Setting Type | Default value | Description |
+| ------------- | ------------ | ------------- | ----------- |
+| `$(MSBuildCacheCredentialsType)` | `string` | "Interactive" | Indicates the credential type to use for authentication. Valid values are "Interactive", "ConnectionString", "ManagedIdentity" |
+| `$(MSBuildCacheBlobUri)` | `Uri` | | Specifies the uri of the Azure Storage Blob. |
+| `$(MSBuildCacheManagedIdentityClientId)` | `string` | | Specifies the managed identity client id when using the "ManagedIdentity" credential type |
+| `$(MSBuildCacheInteractiveAuthTokenDirectory)` | `string` | "%LOCALAPPDATA%\MSBuildCache\AuthTokenCache" | Specifies a token cache directory when using the "ManagedIdentity" credential type |
+
+When using the "ConnectionString" credential type, the connection string to the blob storage account must be provided in the `MSBUILDCACHE_CONNECTIONSTRING` environment variable. This connection string needs both read and write access to the resource.
 
 ## Other Packages
 

--- a/src/AzureBlobStorage/AzureBlobStoragePluginSettings.cs
+++ b/src/AzureBlobStorage/AzureBlobStoragePluginSettings.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.MSBuildCache.AzureBlobStorage;
+
+public class AzureBlobStoragePluginSettings : PluginSettings
+{
+    public AzureStorageCredentialsType CredentialsType { get; init; } = AzureStorageCredentialsType.Interactive;
+
+    public Uri? BlobUri { get; init; }
+
+    public string? ManagedIdentityClientId { get; init; }
+
+    public string InteractiveAuthTokenDirectory { get; init; } = Environment.ExpandEnvironmentVariables(@"%LOCALAPPDATA%\MSBuildCache\AuthTokenCache");
+}

--- a/src/AzureBlobStorage/AzureStorageCredentialsType.cs
+++ b/src/AzureBlobStorage/AzureStorageCredentialsType.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.MSBuildCache.AzureBlobStorage;
+
+/// <summary>
+/// Determines how to authenticate to Azure Storage.
+/// </summary>
+public enum AzureStorageCredentialsType
+{
+    /// <summary>
+    /// Use interactive authentication.
+    /// </summary>
+    Interactive,
+
+    /// <summary>
+    /// Use a connection string to authenticate.
+    /// </summary>
+    /// <remarks>
+    /// The "MSBUILDCACHE_CONNECTIONSTRING" environment variable must contain the connection string to use.
+    /// </remarks>
+    ConnectionString,
+
+    /// <summary>
+    /// Use a managed identity to authenticate.
+    /// </summary>
+    ManagedIdentity,
+}

--- a/src/AzureBlobStorage/build/Microsoft.MSBuildCache.AzureBlobStorage.targets
+++ b/src/AzureBlobStorage/build/Microsoft.MSBuildCache.AzureBlobStorage.targets
@@ -1,3 +1,19 @@
 <Project>
+  <PropertyGroup Condition="'$(MSBuildCacheEnabled)' != 'false'">
+    <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheCredentialsType</MSBuildCacheGlobalPropertiesToIgnore>
+    <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheBlobUri</MSBuildCacheGlobalPropertiesToIgnore>
+    <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheManagedIdentityClientId</MSBuildCacheGlobalPropertiesToIgnore>
+    <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheInteractiveAuthTokenDirectory</MSBuildCacheGlobalPropertiesToIgnore>
+  </PropertyGroup>
+
   <Import Project="Microsoft.MSBuildCache.Common.targets" />
+
+  <ItemGroup Condition="'$(MSBuildCacheEnabled)' != 'false'">
+    <ProjectCachePlugin Update="$(MSBuildCacheAssembly)">
+      <CredentialsType>$(MSBuildCacheCredentialsType)</CredentialsType>
+      <BlobUri>$(MSBuildCacheBlobUri)</BlobUri>
+      <ManagedIdentityClientId>$(MSBuildCacheManagedIdentityClientId)</ManagedIdentityClientId>
+      <InteractiveAuthTokenDirectory>$(MSBuildCacheInteractiveAuthTokenDirectory)</InteractiveAuthTokenDirectory>
+  </ProjectCachePlugin>
+  </ItemGroup>
 </Project>

--- a/src/Common/PluginSettings.cs
+++ b/src/Common/PluginSettings.cs
@@ -243,6 +243,20 @@ public class PluginSettings
             return settingValue == null ? SettingParseResult.InvalidValue : SettingParseResult.Success;
         }
 
+        if (type == typeof(Uri))
+        {
+            if (Uri.TryCreate(rawSettingValue, UriKind.Absolute, out Uri? uri))
+            {
+                settingValue = uri;
+                return SettingParseResult.Success;
+            }
+            else
+            {
+                settingValue = null;
+                return SettingParseResult.InvalidValue;
+            }
+        }
+
         if (type == typeof(Glob))
         {
             string globSpec = rawSettingValue;

--- a/src/Common/SourceControl/GitFileHashProvider.cs
+++ b/src/Common/SourceControl/GitFileHashProvider.cs
@@ -60,7 +60,7 @@ internal sealed class GitFileHashProvider : ISourceControlFileHashProvider
         }
 
         // Iterate through the initialized submodules and add those hashes
-        IList<string> submodules = await GetInitializedSubmodulesAsync(repoRoot, cancellationToken);
+        List<string> submodules = await GetInitializedSubmodulesAsync(repoRoot, cancellationToken);
 
         if (submodules.Count == 0)
         {


### PR DESCRIPTION
This change adds additional credential types to the AzureBlobStorage plugin, including interactive auth and using a managed identity.