### PR TITLE
Tolerate dependencies outside the repo when adding to cache

### DIFF
--- a/src/Common/Fingerprinting/FingerprintFactory.cs
+++ b/src/Common/Fingerprinting/FingerprintFactory.cs
@@ -35,19 +35,22 @@ public sealed class FingerprintFactory : IFingerprintFactory
     private readonly List<FingerprintEntry> _pluginSettingsFingerprintEntries;
     private readonly PluginSettings _pluginSettings;
     private readonly PathNormalizer _pathNormalizer;
+    private readonly string _repoRoot;
 
     public FingerprintFactory(
         IContentHasher contentHasher,
         IInputHasher inputHasher,
         INodeContextRepository nodeRepository,
         PluginSettings pluginSettings,
-        PathNormalizer pathNormalizer)
+        PathNormalizer pathNormalizer,
+        string repoRoot)
     {
         _contentHasher = contentHasher;
         _inputHasher = inputHasher;
         _nodeContextRepository = nodeRepository;
         _pluginSettings = pluginSettings;
         _pathNormalizer = pathNormalizer;
+        _repoRoot = repoRoot;
 
         _pluginSettingsFingerprintEntries = new List<FingerprintEntry>()
         {
@@ -119,6 +122,11 @@ public sealed class FingerprintFactory : IFingerprintFactory
                 {
                     if (!_nodeContextRepository.TryGetNodeContext(dependencyNode.ProjectInstance, out NodeContext? dependency))
                     {
+                        if (!dependencyNode.ProjectInstance.FullPath.IsUnderDirectory(_repoRoot))
+                        {
+                            continue;
+                        }
+
                         return null;
                     }
 


### PR DESCRIPTION
Tolerate dependencies outside the repo when adding to cache.

This supports scenarios like NerdBank.GitVersioning which end up adding a projects inside the package to the graph, which ends up getting ignored.

> Ignoring project outside the repository: D:\Code\.nuget\nerdbank.gitversioning\3.6.139\build\PrivateP2PCaching.proj

Before this change, this would result in all cache misses for repos using NerdBank.GitVersioning.

Note that projects outside of the repo which are built in this manner are not considered at all for cache fingerprinting, so any changes in those projects will not cause projects to rebuild, just like any other file read outside the repo (and outside NuGet packages).