### PR TITLE
Blob: Create InteractiveAuthTokenDirectory if needed

### DIFF
--- a/src/AzureBlobStorage/MSBuildCacheAzureBlobStoragePlugin.cs
+++ b/src/AzureBlobStorage/MSBuildCacheAzureBlobStoragePlugin.cs
@@ -112,6 +112,10 @@ public sealed class MSBuildCacheAzureBlobStoragePlugin : MSBuildCachePluginBase<
                     throw new InvalidOperationException($"{nameof(AzureBlobStoragePluginSettings.BlobUri)} is required when using {nameof(AzureBlobStoragePluginSettings.CredentialsType)}={settings.CredentialsType}");
                 }
 
+                // InteractiveClientStorageCredentials expects the directory to exist.
+                // TODO: Remove after the bug fix makes it into BXL.
+                Directory.CreateDirectory(settings.InteractiveAuthTokenDirectory);
+
                 return new InteractiveClientStorageCredentials(settings.InteractiveAuthTokenDirectory, settings.BlobUri, cancellationToken);
             }
             case AzureStorageCredentialsType.ConnectionString:


### PR DESCRIPTION
Blob: Create InteractiveAuthTokenDirectory if needed

`InteractiveClientStorageCredentials` will throw an exception and then swallow it if `InteractiveAuthTokenDirectory` does not already exist, causing an auth popup to happen every time.

This creates the directory proactively to avoid this.

I'm also following up with the BuildXL team to get a fix into `InteractiveClientStorageCredentials`.