### PR TITLE
Add ability to query nodes recursively if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ These settings are common across all plugins, although different implementations
 | `$(MSBuildCacheAllowFileAccessAfterProjectFinishProcessPatterns)` | `Glob[]` | `\**\vctip.exe` | Processes to allow file accesses after the project which launched it completes, ie accesses by a detached process. Note: these accesses will not be considered for caching. |
 | `$(MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns)` | `Glob[]` | | Files to allow to be accessed by a process launched by a project after the project completes, ie accesses by a detached process. Note: these accesses will not be considered for caching. |
 | `$(MSBuildCacheAllowProcessCloseAfterProjectFinishProcessPatterns)` | `Glob[]` | `\**\mspdbsrv.exe` | Processes to allow to exit after the project which launched it completes, ie detached processes. |
-| `$(MSBuildCacheGlobalPropertiesToIgnore)` | `string[]` | `CurrentSolutionConfigurationContents; ShouldUnsetParentConfigurationAndPlatform; BuildingInsideVisualStudio; BuildingSolutionFile; SolutionDir; SolutionExt; SolutionFileName; SolutionName; SolutionPath; _MSDeployUserAgent`, as well as all proeprties related to plugin settings,  | The list of global properties to exclude from consideration by the cache |
+| `$(MSBuildCacheGlobalPropertiesToIgnore)` | `string[]` | `CurrentSolutionConfigurationContents; ShouldUnsetParentConfigurationAndPlatform; BuildingInsideVisualStudio; BuildingSolutionFile; SolutionDir; SolutionExt; SolutionFileName; SolutionName; SolutionPath; _MSDeployUserAgent`, as well as all proeprties related to plugin settings | The list of global properties to exclude from consideration by the cache |
+| `$(MSBuildCacheGetResultsForUnqueriedDependencies)` | `bool` | false | Whether to try and query the cache for dependencies if they have not previously been requested. This option can help in cases where the build isn't done in graph order, or if some projects are skipped. |
+
+
 
 When configuring settings which are list types, you should always append to the existing value to avoid overriding the defaults:
 

--- a/src/Common.Tests/PluginSettingsTests.cs
+++ b/src/Common.Tests/PluginSettingsTests.cs
@@ -351,16 +351,20 @@ public sealed class PluginSettingsTests
         CollectionAssert.AreEqual(expectedValue, pluginSettings.GlobalPropertiesToIgnore.ToList());
     }
 
+    [TestMethod]
+    public void GetResultsForUnqueriedDependenciesSetting()
+        => TestBoolSetting(nameof(PluginSettings.GetResultsForUnqueriedDependencies), pluginSettings => pluginSettings.GetResultsForUnqueriedDependencies);
+
     private static void TestBoolSetting(string settingName, Func<PluginSettings, bool> valueAccessor)
         => TestBasicSetting(
             settingName,
             valueAccessor,
-            testValues: new[] { false, true });
+            testValues: [false, true]);
 
     private static void TestBasicSetting<T>(
         string settingName,
         Func<PluginSettings, T> valueAccessor,
-        T[] testValues)
+        ReadOnlySpan<T> testValues)
     {
         T defaultValue = valueAccessor(DefaultPluginSettings);
 

--- a/src/Common/PluginSettings.cs
+++ b/src/Common/PluginSettings.cs
@@ -101,6 +101,8 @@ public class PluginSettings
 
     public IReadOnlyList<string> GlobalPropertiesToIgnore { get; init; } = Array.Empty<string>();
 
+    public bool GetResultsForUnqueriedDependencies { get; init; }
+
     public static T Create<T>(
         IReadOnlyDictionary<string, string> settings,
         PluginLoggerBase logger,

--- a/src/Common/build/Microsoft.MSBuildCache.Common.targets
+++ b/src/Common/build/Microsoft.MSBuildCache.Common.targets
@@ -20,6 +20,7 @@
     <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns</MSBuildCacheGlobalPropertiesToIgnore>
     <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheAllowProcessCloseAfterProjectFinishProcessPatterns</MSBuildCacheGlobalPropertiesToIgnore>
     <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheGlobalPropertiesToIgnore</MSBuildCacheGlobalPropertiesToIgnore>
+    <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheGetResultsForUnqueriedDependencies</MSBuildCacheGlobalPropertiesToIgnore>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildCacheEnabled)' != 'false'">
@@ -39,6 +40,7 @@
       <AllowFileAccessAfterProjectFinishFilePatterns>$(MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns)</AllowFileAccessAfterProjectFinishFilePatterns>
       <AllowProcessCloseAfterProjectFinishProcessPatterns>$(MSBuildCacheAllowProcessCloseAfterProjectFinishProcessPatterns)</AllowProcessCloseAfterProjectFinishProcessPatterns>
       <GlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore)</GlobalPropertiesToIgnore>
+      <GetResultsForUnqueriedDependencies>$(MSBuildCacheGetResultsForUnqueriedDependencies)</GetResultsForUnqueriedDependencies>
     </ProjectCachePlugin>
   </ItemGroup>
 


### PR DESCRIPTION
Add ability to query nodes recursively if needed

This feature allows the plugin to on-demand query for dependencies which have not been queried. Most scenarios are expected to do a "graph build" and ensure all dependencies are built first, but some upcoming scenarios might violate that constraint.

This is an opt-in scenario since it adds some overhead and can make cache misses more expensive.