### PR TITLE
Change MSBUILDCACHE_CONNECTIONSTRING -> MSBCACHE_CONNECTIONSTRING

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ These settings are available in addition to the [Common Settings](#common-settin
 | `$(MSBuildCacheManagedIdentityClientId)` | `string` | | Specifies the managed identity client id when using the "ManagedIdentity" credential type |
 | `$(MSBuildCacheInteractiveAuthTokenDirectory)` | `string` | "%LOCALAPPDATA%\MSBuildCache\AuthTokenCache" | Specifies a token cache directory when using the "Interactive" credential type |
 
-When using the "ConnectionString" credential type, the connection string to the blob storage account must be provided in the `MSBUILDCACHE_CONNECTIONSTRING` environment variable. This connection string needs both read and write access to the resource.
+When using the "ConnectionString" credential type, the connection string to the blob storage account must be provided in the `MSBCACHE_CONNECTIONSTRING` environment variable. This connection string needs both read and write access to the resource.
 
 ## Other Packages
 

--- a/src/AzureBlobStorage/AzureStorageCredentialsType.cs
+++ b/src/AzureBlobStorage/AzureStorageCredentialsType.cs
@@ -17,7 +17,7 @@ public enum AzureStorageCredentialsType
     /// Use a connection string to authenticate.
     /// </summary>
     /// <remarks>
-    /// The "MSBUILDCACHE_CONNECTIONSTRING" environment variable must contain the connection string to use.
+    /// The "MSBCACHE_CONNECTIONSTRING" environment variable must contain the connection string to use.
     /// </remarks>
     ConnectionString,
 

--- a/src/AzureBlobStorage/MSBuildCacheAzureBlobStoragePlugin.cs
+++ b/src/AzureBlobStorage/MSBuildCacheAzureBlobStoragePlugin.cs
@@ -28,7 +28,7 @@ namespace Microsoft.MSBuildCache.AzureBlobStorage;
 public sealed class MSBuildCacheAzureBlobStoragePlugin : MSBuildCachePluginBase<AzureBlobStoragePluginSettings>
 {
     // Note: This is not in PluginSettings as that's configured through item metadata and thus makes it into MSBuild logs. This is a secret so that's not desirable.
-    private const string AzureBlobConnectionStringEnvVar = "MSBUILDCACHE_CONNECTIONSTRING";
+    private const string AzureBlobConnectionStringEnvVar = "MSBCACHE_CONNECTIONSTRING";
 
     // Although Azure Blob Storage is unrelated to Azure DevOps, Vso0 hashing is much faster than SHA256.
     protected override HashType HashType => HashType.Vso0;


### PR DESCRIPTION
Env vars prefixed by "MSBuild" automatically get logged, and since this one contains a secret, that's a bad thing.

This renames the environment variable to avoid this.

Note that this is a breaking change!