### PR TITLE
Blob: Add TokenCredential auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,14 @@ These settings are available in addition to the [Common Settings](#common-settin
 
 | MSBuild Property Name | Setting Type | Default value | Description |
 | ------------- | ------------ | ------------- | ----------- |
-| `$(MSBuildCacheCredentialsType)` | `string` | "Interactive" | Indicates the credential type to use for authentication. Valid values are "Interactive", "ConnectionString", "ManagedIdentity" |
+| `$(MSBuildCacheCredentialsType)` | `string` | "Interactive" | Indicates the credential type to use for authentication. Valid values are "Interactive", "ConnectionString", "ManagedIdentity", "TokenCredential" |
 | `$(MSBuildCacheBlobUri)` | `Uri` | | Specifies the uri of the Azure Storage Blob. |
 | `$(MSBuildCacheManagedIdentityClientId)` | `string` | | Specifies the managed identity client id when using the "ManagedIdentity" credential type |
 | `$(MSBuildCacheInteractiveAuthTokenDirectory)` | `string` | "%LOCALAPPDATA%\MSBuildCache\AuthTokenCache" | Specifies a token cache directory when using the "Interactive" credential type |
 
 When using the "ConnectionString" credential type, the connection string to the blob storage account must be provided in the `MSBCACHE_CONNECTIONSTRING` environment variable. This connection string needs both read and write access to the resource.
+
+When using the "TokenCredential" credential type, an access token must be provided in the `MSBCACHE_ACCESSTOKEN` environment variable. Alternately, if using the programmatic project cache API, a [`TokenCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.core.tokencredential?view=azure-dotnet) may be provided in the plugin's constructor.
 
 ## Other Packages
 

--- a/src/AzureBlobStorage/AzureStorageCredentialsType.cs
+++ b/src/AzureBlobStorage/AzureStorageCredentialsType.cs
@@ -25,4 +25,13 @@ public enum AzureStorageCredentialsType
     /// Use a managed identity to authenticate.
     /// </summary>
     ManagedIdentity,
+
+    /// <summary>
+    /// Use a token credential to authenticate.
+    /// </summary>
+    /// <remarks>
+    /// The "MSBCACHE_ACCESSTOKEN" environment variable must contain the access token to use. Alternately if using the programmatic
+    /// project cache API, a TokenCredential may be provided in the plugin's constructor.
+    /// </remarks>
+    TokenCredential,
 }

--- a/src/AzureBlobStorage/StaticTokenCredential.cs
+++ b/src/AzureBlobStorage/StaticTokenCredential.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Azure.Core;
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+
+namespace Microsoft.MSBuildCache.AzureBlobStorage;
+
+internal sealed class StaticTokenCredential : TokenCredential
+{
+    private readonly string _accessToken;
+
+    public StaticTokenCredential(string accessToken)
+    {
+        _accessToken = accessToken;
+    }
+
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        // The token is static and we don't know the expiry, so just say it's a day from now.
+        => new AccessToken(_accessToken, DateTimeOffset.Now.AddDays(1));
+
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        => new ValueTask<AccessToken>(GetToken(requestContext, cancellationToken));
+}

--- a/src/AzureBlobStorage/TokenCredentialAzureStorageCredentials.cs
+++ b/src/AzureBlobStorage/TokenCredentialAzureStorageCredentials.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Azure.Core;
+using BuildXL.Cache.ContentStore.Interfaces.Auth;
+
+namespace Microsoft.MSBuildCache.AzureBlobStorage;
+
+internal sealed class TokenCredentialAzureStorageCredentials : AzureStorageCredentialsBase
+{
+    public TokenCredentialAzureStorageCredentials(Uri blobUri, TokenCredential tokenCredential)
+        : base(blobUri)
+    {
+        Credentials = tokenCredential;
+    }
+
+    protected override TokenCredential Credentials { get; }
+}


### PR DESCRIPTION
This adds a new authentication type which can be used either by providing an access token via env var, or by providing a `TokenCredential` (or access token) in the ctor (when using the programmatic project cache API)