### PR TITLE
Revert "Migrate test projects to MSTest.Sdk"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Services.BlobStore.Client" Version="$(ArtifactsPackageVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Services.BlobStore.Client.Cache" Version="$(ArtifactsPackageVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Services.PipelineCache.WebApi" Version="$(ArtifactsPackageVersion)" />
+    <PackageVersion Include="MSTest" Version="3.5.0" />
     <!--
       An indirect dependency of BXL (Minimatch) depends on a very old and non-existing version of NETStandard.Library (>= 1.0.0-rc2-23910).
       This forces a good version of NETStandard.Library to mitigate.

--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-    "msbuild-sdks": {
-      "MSTest.Sdk": "3.6.1"
-    }
-  }

--- a/src/Common.Tests/Microsoft.MSBuildCache.Common.Tests.csproj
+++ b/src/Common.Tests/Microsoft.MSBuildCache.Common.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSTest.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- Only supports x64 due to the RocksDB dependency -->
     <Platform>x64</Platform>
@@ -11,6 +11,7 @@
     <NoWarn>$(NoWarn);CA1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="MSTest" />
     <PackageReference Include="morelinq" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Repack.Tests/Microsoft.MSBuildCache.Repack.Tests.csproj
+++ b/src/Repack.Tests/Microsoft.MSBuildCache.Repack.Tests.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="MSTest.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- Only supports x64 due to the RocksDB dependency -->
     <Platform>x64</Platform>
-    <Platforms>$(Platform)</Platforms>
+    <Platforms>AnyCPU;x64</Platforms>
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <RootNamespace>Microsoft.MSBuildCache.Repack.Tests</RootNamespace>
     <!-- Suppress "Avoid constant arrays as arguments". UTs have many one-off test data arrays. -->
@@ -11,6 +11,7 @@
     <NoWarn>$(NoWarn);CA1034</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="MSTest" />
     <PackageReference Include="morelinq" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Reverts microsoft/MSBuildCache#99

Broken official builds. Something about strong naming. Ugh.

```
D:\a\_work\1\s\src\Repack.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Repack.Tests.exe : error run failed: Tests failed:  [D:\a\_work\1\s\src\Repack.Tests\Microsoft.MSBuildCache.Repack.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Repack.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Repack.Tests.exe : error run failed: Unhandled Exception: System.IO.FileLoadException: Could not load file or assembly 'Microsoft.MSBuildCache.Repack.Tests, Version=0.1.0.0, Culture=neutral, PublicKey***=6702f781b82f5f3b' or one of its dependencies. Strong name validation failed. (Exception from HRESULT: 0x8013141A) ---> System.Security.SecurityException: Strong name validation failed. (Exception from HRESULT: 0x8013141A) [D:\a\_work\1\s\src\Repack.Tests\Microsoft.MSBuildCache.Repack.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Repack.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Repack.Tests.exe : error run failed:    --- End of inner exception stack trace --- [D:\a\_work\1\s\src\Repack.Tests\Microsoft.MSBuildCache.Repack.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Repack.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Repack.Tests.exe : error run failed:  [D:\a\_work\1\s\src\Repack.Tests\Microsoft.MSBuildCache.Repack.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Repack.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Repack.Tests.exe : error run failed: === COMMAND LINE === [D:\a\_work\1\s\src\Repack.Tests\Microsoft.MSBuildCache.Repack.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Repack.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Repack.Tests.exe : error run failed: D:\a\_work\1\s\src\Repack.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Repack.Tests.exe --internal-msbuild-node testingplatform.pipe.9eac05d720244ab9a58898088e82d1f8  [D:\a\_work\1\s\src\Repack.Tests\Microsoft.MSBuildCache.Repack.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Repack.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Repack.Tests.exe : error run failed:  [D:\a\_work\1\s\src\Repack.Tests\Microsoft.MSBuildCache.Repack.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Repack.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Repack.Tests.exe : error run failed:  [D:\a\_work\1\s\src\Repack.Tests\Microsoft.MSBuildCache.Repack.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Common.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Common.Tests.exe : error run failed: Tests failed:  [D:\a\_work\1\s\src\Common.Tests\Microsoft.MSBuildCache.Common.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Common.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Common.Tests.exe : error run failed: Unhandled Exception: System.IO.FileLoadException: Could not load file or assembly 'Microsoft.MSBuildCache.Common.Tests, Version=0.1.0.0, Culture=neutral, PublicKey***=6702f781b82f5f3b' or one of its dependencies. Strong name validation failed. (Exception from HRESULT: 0x8013141A) ---> System.Security.SecurityException: Strong name validation failed. (Exception from HRESULT: 0x8013141A) [D:\a\_work\1\s\src\Common.Tests\Microsoft.MSBuildCache.Common.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Common.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Common.Tests.exe : error run failed:    --- End of inner exception stack trace --- [D:\a\_work\1\s\src\Common.Tests\Microsoft.MSBuildCache.Common.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Common.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Common.Tests.exe : error run failed:  [D:\a\_work\1\s\src\Common.Tests\Microsoft.MSBuildCache.Common.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Common.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Common.Tests.exe : error run failed: === COMMAND LINE === [D:\a\_work\1\s\src\Common.Tests\Microsoft.MSBuildCache.Common.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Common.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Common.Tests.exe : error run failed: D:\a\_work\1\s\src\Common.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Common.Tests.exe --internal-msbuild-node testingplatform.pipe.4298a9180474405fad9876f4444ae58a  [D:\a\_work\1\s\src\Common.Tests\Microsoft.MSBuildCache.Common.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Common.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Common.Tests.exe : error run failed:  [D:\a\_work\1\s\src\Common.Tests\Microsoft.MSBuildCache.Common.Tests.csproj::TargetFramework=net472]
D:\a\_work\1\s\src\Common.Tests\bin\x64\Release\net472\Microsoft.MSBuildCache.Common.Tests.exe : error run failed:  [D:\a\_work\1\s\src\Common.Tests\Microsoft.MSBuildCache.Common.Tests.csproj::TargetFramework=net472]
    0 Warning(s)
    2 Error(s)
```