### PR TITLE
Blob: Remove branch from cache universe

### DIFF
--- a/src/Common/SourceControl/Git.cs
+++ b/src/Common/SourceControl/Git.cs
@@ -12,19 +12,10 @@ using Process = Microsoft.MSBuildCache.SourceControl.GitProcess;
 
 namespace Microsoft.MSBuildCache.SourceControl;
 
-public static class Git
+internal static class Git
 {
     // UTF8 - NO BOM
     private static readonly Encoding InputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
-    public static async Task<string> BranchNameAsync(PluginLoggerBase logger, string repoRoot)
-    {
-        string branchName = await RunAsync(logger, repoRoot, "rev-parse --abbrev-ref HEAD",
-            (_, stdout) => stdout.ReadToEndAsync(),
-            (exitCode, result) => result,
-            CancellationToken.None);
-        return branchName.Trim();
-    }
 
     public static async Task<T> RunAsync<T>(
         PluginLoggerBase logger,


### PR DESCRIPTION
The original intent was to match Azure Pipeline Caching which has a hierarchy of caches, where the current branch has a Read/Write cache, while parent branches like `main` would have a cache with read-only access. [Details](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#cache-isolation-and-security) for the interested for how that works.

However, this simply added the branch name to the cache universe, which isolated but did not actually add any security. It also didn't add any of the hierarchy logic, meaning branches were _completely_ isolated, which is not desirable.

This change just removes that logic.