### PR TITLE
Fix race condition for writing local cache state

### DIFF
--- a/src/Common/Caching/CacheClient.cs
+++ b/src/Common/Caching/CacheClient.cs
@@ -490,13 +490,12 @@ public abstract class CacheClient : ICacheClient
 
             Task placeFilesTask = cacheEntry.PlaceFilesAsync(context, outputsToPlace, ct);
             tasks.Add(placeFilesTask);
+            await Task.WhenAll(tasks);
 
             if (_localCacheStateManager is not null)
             {
                 await _localCacheStateManager.WriteStateFileAsync(nodeContext, nodeBuildResult);
             }
-
-            await Task.WhenAll(tasks);
         }
 
         if (_enableAsyncMaterialization)


### PR DESCRIPTION
This moves the call to after the await for the placement tasks. Previously those tasks might still be executing so could lead to a race condition where the output file didn't exist on disk yet.

Example exception that was being seen previously:

```
System.IO.FileNotFoundException: Could not find file '<redacted>'.
File name: '<redacted>'
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileInfo.get_Length()
   at Microsoft.MSBuildCache.Caching.LocalCacheStateManager.<WriteStateFileAsync>d__5.MoveNext() in D:\a\_work\1\s\src\Common\Caching\LocalCacheStateManager.cs:line 43
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.MSBuildCache.Caching.CacheClient.<>c__DisplayClass55_0.<<GetNodeInternalAsync>g__PlaceFilesAsync|1>d.MoveNext() in D:\a\_work\1\s\src\Common\Caching\CacheClient.cs:line 499
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.MSBuildCache.Caching.CacheClient.<GetNodeInternalAsync>d__55.MoveNext() in D:\a\_work\1\s\src\Common\Caching\CacheClient.cs:line 518
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.MSBuildCache.Caching.CacheClient.<GetNodeAsync>d__54.MoveNext() in D:\a\_work\1\s\src\Common\Caching\CacheClient.cs:line 362
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.<GetCacheResultSingleAsync>d__61.MoveNext() in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 452
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.<>c__DisplayClass59_0.<<GetCacheResultRecursivelyAsync>b__0>d.MoveNext() in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 424
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.<GetCacheResultRecursivelyAsync>d__59.MoveNext() in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 404
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.<>c__DisplayClass59_0.<<GetCacheResultRecursivelyAsync>b__0>d.MoveNext() in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 412
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.<GetCacheResultRecursivelyAsync>d__59.MoveNext() in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 404
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.<>c__DisplayClass59_0.<<GetCacheResultRecursivelyAsync>b__0>d.MoveNext() in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 412
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.<GetCacheResultRecursivelyAsync>d__59.MoveNext() in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 404
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.<GetCacheResultInnerAsync>d__58.MoveNext() in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 393
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.<TimeAndLogAsync>d__84`1.MoveNext()
```