### PR TITLE
Avoid logging warnings when cancellation is requested

### DIFF
--- a/src/Common/Caching/CacheClient.cs
+++ b/src/Common/Caching/CacheClient.cs
@@ -453,7 +453,7 @@ public abstract class CacheClient : ICacheClient
             {
                 Tracer.Warning(context, $"Package content `{sourceAbsolutePath}` was not copied to `{destinationAbsolutePath}` because package content `{firstSourceAbsolutePath}` already was.");
             }
-        };
+        }
 
         async Task PlaceFilesAsync(CancellationToken ct)
         {

--- a/src/Common/PluginSettings.cs
+++ b/src/Common/PluginSettings.cs
@@ -390,7 +390,7 @@ public class PluginSettings
 
                     return SettingParseResult.Success;
                 }
-            };
+            }
         }
 
         settingValue = null;

--- a/src/Common/SourceControl/Git.cs
+++ b/src/Common/SourceControl/Git.cs
@@ -77,6 +77,7 @@ internal static class Git
 
 #if NETFRAMEWORK
                 process.WaitForExit();
+                cancellationToken.ThrowIfCancellationRequested();
 #else
                 await process.WaitForExitAsync(cancellationToken);
 #endif
@@ -92,6 +93,6 @@ internal static class Git
 
                 return onExit(process.ExitCode, await resultTask);
             }
-        };
+        }
     }
 }


### PR DESCRIPTION
This avoid logging a warning when cancellation is requested and instead logs a debug level message.

There is also some light refactoring of the sync TimeAndLog path to avoid Task overhead.

Note that cancellation exceptions are still rethrown now which crashes MSBuild. This will need to be addressed from within MSBuild itself.