### PR TITLE
Touch up-to-date files to assist incremental builds

### DIFF
--- a/src/Common/Caching/LocalCacheStateManager.cs
+++ b/src/Common/Caching/LocalCacheStateManager.cs
@@ -87,11 +87,26 @@ internal sealed class LocalCacheStateManager
 
         List<KeyValuePair<string, ContentHash>> outOfDateFiles = new(nodeBuildResult.Outputs.Count);
 
+        // When touching files, use the same timestamp for every file to ensure we don't end up with some outputs with slightly different timestamps, which may lead to missed incrementality.
+        DateTime fileTimestamp = DateTime.Now;
+
         foreach (KeyValuePair<string, ContentHash> kvp in nodeBuildResult.Outputs)
         {
             string relativeFilePath = kvp.Key;
             ContentHash contentHash = kvp.Value;
-            if (!IsFileUpToDate(context, depFile, relativeFilePath, contentHash))
+            if (IsFileUpToDate(context, depFile, relativeFilePath, contentHash))
+            {
+                // Avoid touching the reference assembly as incremental build functionality heavily depends on this file not being updated when it does not change.
+                if (string.Equals(relativeFilePath, nodeContext.ReferenceAssemblyRelativePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Touch the file to ensure incremental builds understand that the file is up to date
+                string absoluteFilePath = Path.Combine(_repoRoot, relativeFilePath);
+                File.SetLastWriteTime(absoluteFilePath, fileTimestamp);
+            }
+            else
             {
                 outOfDateFiles.Add(kvp);
             }

--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -293,7 +293,15 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
             nodeDependencies.Add(node, dependencies);
 
             NodeDescriptor nodeDescriptor = _nodeDescriptorFactory.Create(node.ProjectInstance);
-            NodeContext nodeContext = new(Settings.LogDirectory, node.ProjectInstance, dependencies, parserInfo.ProjectFileRelativePath, nodeDescriptor.FilteredGlobalProperties, inputs, targetNames);
+            NodeContext nodeContext = new(
+                Settings.LogDirectory,
+                node.ProjectInstance,
+                dependencies,
+                parserInfo.ProjectFileRelativePath,
+                nodeDescriptor.FilteredGlobalProperties,
+                inputs,
+                parserInfo.ReferenceAssemblyRelativePath,
+                targetNames);
 
             dumpParserInfoTasks.Add(Task.Run(() => DumpParserInfoAsync(logger, nodeContext, parserInfo), cancellationToken));
             _nodeContexts.Add(nodeDescriptor, nodeContext);

--- a/src/Common/NodeContext.cs
+++ b/src/Common/NodeContext.cs
@@ -12,8 +12,8 @@ namespace Microsoft.MSBuildCache;
 
 public sealed class NodeContext
 {
-    private static readonly byte[] PropertyHashDelimiter = new byte[] { 0x01 };
-    private static readonly byte[] PropertyValueHashDelimiter = new byte[] { 0x02 };
+    private static readonly byte[] PropertyHashDelimiter = [0x01];
+    private static readonly byte[] PropertyValueHashDelimiter = [0x02];
 
     private readonly string _logDirectory;
     private bool _logDirectoryCreated;
@@ -25,6 +25,7 @@ public sealed class NodeContext
         string projectFileRelativePath,
         IReadOnlyDictionary<string, string> filteredGlobalProperties,
         IReadOnlyList<string> inputs,
+        string? referenceAssemblyRelativePath,
         HashSet<string> targetNames)
     {
         Id = GenerateId(projectFileRelativePath, filteredGlobalProperties);
@@ -34,6 +35,7 @@ public sealed class NodeContext
         ProjectFileRelativePath = projectFileRelativePath;
         FilteredGlobalProperties = filteredGlobalProperties;
         Inputs = inputs;
+        ReferenceAssemblyRelativePath = referenceAssemblyRelativePath;
         TargetNames = targetNames;
     }
 
@@ -63,6 +65,8 @@ public sealed class NodeContext
     public IReadOnlyDictionary<string, string> FilteredGlobalProperties { get; }
 
     public IReadOnlyList<string> Inputs { get; }
+
+    public string? ReferenceAssemblyRelativePath { get; }
 
     public HashSet<string> TargetNames { get; }
 


### PR DESCRIPTION
This change touches up-to-date files when the `MSBuildCacheSkipUnchangedOutputFiles` feature is being used. This helps incremental builds understand that the files are up-to-date as well.

There is a special case for ref assemblies, as there is a strong dependency on that file *not* being updated when it does not change.