### PR TITLE
Avoid materializing outputs for unqueried dependencies

### DIFF
--- a/src/Common/Caching/ICacheClient.cs
+++ b/src/Common/Caching/ICacheClient.cs
@@ -19,7 +19,7 @@ public interface ICacheClient : IAsyncDisposable
         Func<IReadOnlyDictionary<string, ContentHash>, NodeBuildResult> nodeBuildResultBuilder,
         CancellationToken cancellationToken);
 
-    Task<(PathSet?, NodeBuildResult?)> GetNodeAsync(NodeContext nodeContext, CancellationToken cancellationToken);
+    Task<(PathSet?, NodeBuildResult?)> GetNodeAsync(NodeContext nodeContext, bool materializeOutputs, CancellationToken cancellationToken);
 
     Task ShutdownAsync(CancellationToken cancellationToken);
 }

--- a/src/Common/ProjectInstanceExtensions.cs
+++ b/src/Common/ProjectInstanceExtensions.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Execution;
+
+namespace Microsoft.MSBuildCache;
+
+internal static class ProjectInstanceExtensions
+{
+    /// <summary>
+    /// Parses a property that may contain a bool, returning the default value if the property is not
+    /// set, or returns false if the property is set to 'false', otherwise returning true.
+    /// </summary>
+    public static bool GetBoolPropertyValue(this ProjectInstance projectInstance, string propName, bool defaultValue = false)
+    {
+        string prop = projectInstance.GetPropertyValue(propName);
+        if (string.IsNullOrWhiteSpace(prop))
+        {
+            return defaultValue;
+        }
+
+        if (string.Equals(prop, "false", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static bool IsPlatformNegotiationBuild(this ProjectInstance projectInstance)
+    {
+        // the fact that there is zero global properties here allows us to determine this was an evaluation done for the sole use of determining a referenced project's compatible platforms. We know that this is a build for this use
+        // because "IsGraphBuild" will be set to true in the global properties of all other project instances.
+        return projectInstance.IsPlatformNegotiationEnabled() && projectInstance.GlobalProperties.Count == 0;
+    }
+
+    public static bool IsPlatformNegotiationEnabled(this ProjectInstance projectInstance)
+    {
+        // Determine whether or not the platform negotiation is turned on in msbuild
+        return !string.IsNullOrWhiteSpace(projectInstance.GetPropertyValue("EnableDynamicPlatformResolution"));
+    }
+
+    public static bool IsInnerBuild(this ProjectInstance projectInstance)
+    {
+        // This follows the logic of MSBuild's ProjectInterpretation.GetProjectType.
+        // See: https://github.com/microsoft/msbuild/blob/master/src/Build/Graph/ProjectInterpretation.cs
+        return !projectInstance.IsPlatformNegotiationBuild() && !string.IsNullOrWhiteSpace(projectInstance.GetPropertyValue(projectInstance.GetPropertyValue("InnerBuildProperty"))) && !string.IsNullOrWhiteSpace(projectInstance.GetPropertyValue(projectInstance.GetPropertyValue("InnerBuildPropertyValues")));
+    }
+
+    public static bool IsOuterBuild(this ProjectInstance projectInstance)
+    {
+        // This follows the logic of MSBuild's ProjectInterpretation.GetProjectType.
+        // See: https://github.com/microsoft/msbuild/blob/master/src/Build/Graph/ProjectInterpretation.cs
+        return !projectInstance.IsPlatformNegotiationBuild() && !projectInstance.IsInnerBuild() && !string.IsNullOrWhiteSpace(projectInstance.GetPropertyValue(projectInstance.GetPropertyValue("InnerBuildPropertyValues")));
+    }
+}


### PR DESCRIPTION
When using the `MSBuildCacheGetResultsForUnqueriedDependencies` feature, today the unqueried dependencies' outputs are materialized on disk, assuming they're cache hits. This is problematic because the caller did not explicitly ask for those nodes and thus may be assuming that those outputs are not changing in any way.

This change avoids materializing outputs for unqueried dependencies.

There is special-casing for outer builds of multitargeting projects. Outer builds depend on the inner builds, so if only the outer build were materialized, almost nothing would end up materializing. So we do still materialize dependencies if the project is an outer build and the dependency is an inner build.

Note that there was some debate around this (I was the hold-out), so capturing the gist of the discussion here to help anyone looking back on this for historical context.
* What if the dependency's outputs are out-of-date or worse missing entirely? This scenario is quite unlikely and would suggest a bug in the caller if this was a real problem. The caller may have determined the current state of the dependency is "good enough" and does not demand exact correctness. Comparing with other systems, in Visual Studio if there is a project which is marked to not build or not in the sln at all, VS will happily avoid it and build projects which depend on it. In all likelihood, those projects will fail, but in the exceedingly strange case that they don't (eg the don't actually depend on their dependency and perhaps set ReferenceOutputAssembly=false or something), then VS would also leave the disk in a state where the dependency is left unbuilt. So at worst, this matches VS's behavior so there's some consistency within the ecosystem.
* What's problematic about materializing the files? Well in the case of projects A and B both depending on D, and D is the unqueried dependency, and A and B have no relationship, then there is a race condition where the processing of A might cause D to materialize, and concurrent processing of B might see inconsistent state for D and make irrational decisions based on that.