### PR TITLE
Disable NuGet fallback dir to avoid non-determinism

### DIFF
--- a/src/Common/build/Microsoft.MSBuildCache.Common.props
+++ b/src/Common/build/Microsoft.MSBuildCache.Common.props
@@ -1,4 +1,16 @@
 <Project>
+  <PropertyGroup>
+    <!--
+      Do not read assemblies from the NugetFallbackFolder since this causes non-determinism with packages
+      sometimes being pulled from the NuGet cache and sometimes pulled from the NugetFallbackFolder, which
+      can causes cache misses.
+
+      Note that the NugetFallbackFolder no longer is created, but it may still exist on machines which ever
+      had older versions of the .NET SDK (< 3.0?) installed.
+    -->
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+  </PropertyGroup>
+
   <!--
     Defaults for well-known files which should be ignored. These are generally intermediate files used for incremental builds and can be safely ignored.
     The reason to ignore these files is if a referencing project can trigger one of these files to be written, usually to cache some expensive computation in that project.


### PR DESCRIPTION
Disable NuGet fallback dir to avoid non-determinism.

This can cause differing fingerprints leading to cache misses:
![image](https://github.com/user-attachments/assets/2b358df8-6015-4e5c-8f2f-374ce6ca0c54)
![image](https://github.com/user-attachments/assets/0bf12a65-0b7f-4366-bb12-d5599819b8dd)

This change disables the defunct feature (it no longer ships with recent versions of the SDK).