### PR TITLE
Update CopyOnWrite to 0.5.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="CopyOnWrite" Version="0.3.8" />
+    <PackageVersion Include="CopyOnWrite" Version="0.5.0" />
     <PackageVersion Include="DotNet.Glob" Version="2.0.3" />
     <PackageVersion Include="ILRepack" Version="2.0.27" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />


### PR DESCRIPTION
The primary motivation is to get https://github.com/microsoft/CopyOnWrite/pull/52, which removes some overhead of `async` calls (which were always synchronous anyway).

Since in Windows 11 24H2, CoW is automatic, we should consider at some point removing this and letting the OS handle it.