### PR TITLE
Log Path.GetFullPath input path in FileAccessRepository when there's an exception

### DIFF
--- a/src/Common/FileAccess/FileAccessRepository.cs
+++ b/src/Common/FileAccess/FileAccessRepository.cs
@@ -167,7 +167,15 @@ internal sealed class FileAccessRepository : IDisposable
                 // Augmented file accesses may not be in a canonical form (may have "..\..\")
                 if (isAnAugmentedFileAccess)
                 {
-                    path = Path.GetFullPath(path);
+                    try
+                    {
+                        path = Path.GetFullPath(path);
+                    }
+                    catch (NotSupportedException ex)
+                    {
+                        throw new NotSupportedException(
+                            $"Path.GetFullPath failed for path: `{path}`. Node Id: {_nodeContext.Id}, Process Id: {fileAccessData.ProcessId}", ex);
+                    }
                 }
 
                 if (operation == ReportedFileOperation.Process)


### PR DESCRIPTION
I'm getting the following error message in my build:

```
##[warning]HandleFileAccess failed after 0 ms: System.NotSupportedException: The given path's format is not supported.
  at System.Security.Permissions.FileIOPermission.EmulateFileIOPermissionChecks(String fullPath)
  at System.Security.Permissions.FileIOPermission.QuickDemand(FileIOPermissionAccess access, String fullPath, Boolean checkForDuplicates, Boolean needFullPath)
  at Microsoft.MSBuildCache.FileAccess.FileAccessRepository.FileAccessesState.AddFileAccess(FileAccessData fileAccessData) in D:\a\_work\1\s\src\Common\FileAccess\FileAccessRepository.cs:line 173
  at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.HandleFileAccessInner(FileAccessContext fileAccessContext, FileAccessData fileAccessData) in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 511
  at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.<>c__DisplayClass62_0.<HandleFileAccess>b__0() in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 491
  at Microsoft.MSBuildCache.MSBuildCachePluginBase`1.TimeAndLog(PluginLoggerBase logger, Action inner, String memberName) in D:\a\_work\1\s\src\Common\MSBuildCachePluginBase.cs:line 1329
```

Having this would help debug it