### PR TITLE
[SFI-ES5.2] Bump .NET SDK pin to 10.0.300 in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.300",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
## Summary

Bumps the `global.json` `sdk.version` pin from `10.0.100` → `10.0.300` to address
**SFI-ES5.2 / DOTNET-Security-10.0** (S360 service `9456803b-2bcc-42dd-aa63-caff3ea00dcd`).

`10.0.300` ships with the .NET 10.0.8 runtime, which incorporates every .NET 10.x
security advisory released to date (10.0.3, 10.0.4, 10.0.6, 10.0.7, 10.0.8).

Note: Component Governance previously observed `10.0.102` on this repo — that is the
result of the existing `"rollForward": "latestFeature"` selecting the latest installed
feature band rather than the pinned `10.0.100` literal. The pin itself was `10.0.100`
prior to this change.

## Why the latest-10.0.x patch instead of the lowest patched

The alert does not cite a specific CVE, so there is no single "minimum patched version"
to target. Every 10.0.x security runtime since 10.0.2 (i.e. 10.0.3, .4, .6, .7, .8) is
in scope. Pinning to the lowest of those would immediately re-trigger CG against the
more recent advisories. Pinning to `10.0.300` (runtime 10.0.8, the latest GA) clears
the entire .NET 10.x advisory backlog in a single move.

References:
- https://github.com/dotnet/core/blob/main/release-notes/10.0/10.0.8/10.0.8.md
- https://raw.githubusercontent.com/dotnet/core/main/release-notes/10.0/releases.json

## Validation

- `dotnet --version` on this branch: `10.0.300` ✅
- `dotnet build MSBuildCache.sln -c Release -nologo`: **fails with 3 `MSB3073` errors**
  from `build/MSBuildExtensionPackage.targets(88,5)` (ILRepack 2.0.44 exiting with code
  1 for `Microsoft.MSBuildCache.AzureBlobStorage`, `Microsoft.MSBuildCache.AzurePipelines`,
  and `Microsoft.MSBuildCache.Local` on the `net9.0` TFM).

  **This failure pre-exists on `main` at `01366ea` and is not caused by this PR.** It
  was reproduced on a clean worktree of `main @ 01366ea` with the identical 3 errors
  on the identical 3 projects at the identical `MSBuildExtensionPackage.targets(88,5)`
  line. Root cause is a duplicate `System.Text.Json.ConverterStrategy` symbol between
  the merge inputs (see the ILRepack warnings printed before the failure). Fixing that
  is out of scope for an SDK-pin bump and should be tracked separately.

## Scope

- Files changed: `global.json` only (1 file, +1 / -1).
- No changes to `rollForward`, `msbuild-sdks`, `test.runner`, or any `PackageReference`.

KPI: SFI-ES5.2
