### PR TITLE
Bump .NET SDK pin in global.json to 10.0.103 (CVE-2026-21218, alert 1…

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.103",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
…2340720)

Fixes CVE-2026-21218 (.NET security feature bypass). Updates sdk.version from 10.0.100 to 10.0.103 in global.json. rollForward=latestFeature preserved.