### PR TITLE
Fix PR-CI E2E jobs for the .NET 10 SDK / VS 2026 toolchain

### DIFF
--- a/.azuredevops/pipelines/pr-ci.yml
+++ b/.azuredevops/pipelines/pr-ci.yml
@@ -88,13 +88,13 @@ jobs:
   # - task: Cache@2
   #   displayName: Cache Visual Studio
   #   inputs:
-  #     key: '"vs-release" | "$(Agent.OS)"'
+  #     key: '"vs" | "$(Agent.OS)"'
   #     path: $(VsInstallDir)
 
   - script: |
       del %TEMP%\vs_buildtools.exe
       
-      curl.exe -L https://aka.ms/vs/17/release/vs_buildtools.exe -o %TEMP%\vs_buildtools.exe
+      curl.exe -L https://aka.ms/vs/18/stable/vs_buildtools.exe -o %TEMP%\vs_buildtools.exe
       
       %TEMP%\vs_buildtools.exe ^
         --config "$(Build.SourcesDirectory)\.vsconfig" ^
@@ -124,12 +124,12 @@ jobs:
     artifact: '$(System.JobDisplayName) logs'
     condition: always()
 
-- job: E2ETestVS2026
-  displayName: E2E Tests using VS 2026
+- job: E2ETestMSBuildRepo
+  displayName: E2E Tests using tip of MSBuild repo
   dependsOn: Build
   variables:
     VsInstallDir: $(Build.ArtifactStagingDirectory)\vs
-    MSBuildPath: $(VsInstallDir)\MSBuild\Current\Bin\amd64\MSBuild.exe
+    MSBuildPath: $(Build.SourcesDirectory)\msbuild\artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\amd64\MSBuild.exe
   steps:
   - download: current
     displayName: 'Download Build Artifacts'
@@ -137,20 +137,18 @@ jobs:
 
   - checkout: self
 
-  # Avoiding Caching VS for now as the installer command we're using doesn't work for upgrades
-  # - task: Cache@2
-  #   displayName: Cache Visual Studio
-  #   inputs:
-  #     key: '"vs-2026" | "$(Agent.OS)"'
-  #     path: $(VsInstallDir)
+  - checkout: msbuild
 
+  # Building tip-of-main MSBuild requires a full Visual Studio; build.cmd locates it via vswhere,
+  # so installing VS here (regardless of install path) satisfies that lookup and is also available
+  # to the E2E test that runs the bootstrapped MSBuild.
   - script: |
       del %TEMP%\vs_buildtools.exe
-      
+
       curl.exe -L https://aka.ms/vs/18/stable/vs_buildtools.exe -o %TEMP%\vs_buildtools.exe
-      
+
       %TEMP%\vs_buildtools.exe ^
-        --config "$(Build.SourcesDirectory)\.vsconfig" ^
+        --config "$(Build.SourcesDirectory)\MSBuildCache\.vsconfig" ^
         --installPath "$(VsInstallDir)" ^
         --passive ^
         --norestart ^
@@ -163,33 +161,9 @@ jobs:
       mkdir "$(LogDirectory)\VSSetup"
       move "%TEMP%\dd_*" "$(LogDirectory)\VSSetup\"
 
-      echo Current MSBuild version:
-      "$(MSBuildPath)" --version
-    displayName: 'Install VS 2026'
-
-  - template: templates\e2e-test.yml
-    parameters:
-      RepoRoot: $(Build.SourcesDirectory)
-      MSBuildPath: $(MSBuildPath)
-
-  - publish: $(LogDirectory)
-    displayName: Publish Logs
-    artifact: '$(System.JobDisplayName) logs'
-    condition: always()
-
-- job: E2ETestMSBuildRepo
-  displayName: E2E Tests using tip of MSBuild repo
-  dependsOn: Build
-  variables:
-    MSBuildPath: $(Build.SourcesDirectory)\msbuild\artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\amd64\MSBuild.exe
-  steps:
-  - download: current
-    displayName: 'Download Build Artifacts'
-    artifact: artifacts
-
-  - checkout: self
-
-  - checkout: msbuild
+      echo Installed VS MSBuild version:
+      "$(VsInstallDir)\MSBuild\Current\Bin\amd64\MSBuild.exe" --version
+    displayName: 'Install VS'
 
   - task: Cache@2
     displayName: Cache MSBuild


### PR DESCRIPTION
# Fix PR-CI E2E jobs for the .NET 10 SDK / VS 2026 toolchain

## Summary

The repo now builds against the .NET 10 SDK (`DotNetVersion: '10.x'`), which is no longer compatible with VS2022's MSBuild. This breaks two of the PR-CI E2E jobs. This change updates `.azuredevops/pipelines/pr-ci.yml` so the E2E jobs use a Visual Studio version that works with the current toolchain.

## Changes

- **Drop the VS2022 E2E job.** The E2E job that installed VS2022 (`aka.ms/vs/17/release/vs_buildtools.exe`) is removed — its E2E test build fails because the .NET 10 SDK no longer works with VS2022's MSBuild.
- **Make the VS 2026 job the canonical VS E2E job.** The job that installs VS 2026 (`aka.ms/vs/18/stable/vs_buildtools.exe`) becomes the single "E2E Tests using VS" job — the job id and display names drop the "2026" suffix while keeping the VS 2026 installer.
- **Install Visual Studio in the "tip of MSBuild repo" E2E job.** A VS install step (the same `vs/18/stable` installer) is added before the "Build MSBuild" step. Building `dotnet/msbuild` at tip of main (`build.cmd /p:CreateBootstrap=true`) requires a full Visual Studio >= 18.6, located via vswhere. The hosted `windows-latest` image only ships VS2022 (17.x), so the build previously failed with `No instance of Visual Studio meeting the requirements specified was found ... -version 18.6`. The installed VS is discoverable by vswhere regardless of install path and is also available to the E2E test that runs the bootstrapped MSBuild.

## Why

The move to the .NET 10 SDK / VS 2026 toolchain means VS2022 can no longer drive the E2E test builds, and building MSBuild at tip of main now demands VS >= 18.6 that the hosted image doesn't provide. The `vs/18/stable` channel currently provides VS 18.8, which satisfies MSBuild's >= 18.6 requirement.

## Testing / validation

These failures reproduce directly on the project's PR-CI: prior to this change the VS2022 E2E job and the MSBuild-repo E2E job fail, while the VS 2026 E2E job passes. This PR's own CI run provides the end-to-end confirmation that the updated jobs succeed.
