### PR TITLE
Fix duplicate output producer registration

### DIFF
--- a/src/Common.Tests/MSBuildCachePluginBaseTests.cs
+++ b/src/Common.Tests/MSBuildCachePluginBaseTests.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using BuildXL.Cache.ContentStore.Hashing;
+using DotNet.Globbing;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Microsoft.MSBuildCache.Tests.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.MSBuildCache.Tests;
+
+[TestClass]
+public sealed class MSBuildCachePluginBaseTests
+{
+    private const string RepoRoot = @"X:\Repo";
+    private const string UniqueOutputPath = "a.unique";
+    private const string DuplicateOutputPath = "z.duplicate";
+    private const string TrailingUniqueOutputPath = "zz.unique";
+
+    [TestMethod]
+    public void CheckForDuplicateOutputsDetectsConflictingDuplicateAfterUniqueOutput()
+    {
+        ContentHash previousHash = ContentHash.Random();
+        ContentHash newHash = ContentHash.Random();
+        while (newHash == previousHash)
+        {
+            newHash = ContentHash.Random();
+        }
+
+        NodeContext previousNode = CreateNode("previous.proj");
+        previousNode.SetBuildResult(CreateBuildResult(previousHash));
+        NodeContext currentNode = CreateNode("current.proj", [previousNode]);
+        ConcurrentDictionary<string, NodeContext> outputProducer = CreateOutputProducer(previousNode);
+        MockPluginLogger logger = new();
+
+        CheckForDuplicateOutputs(
+            logger,
+            outputProducer,
+            currentNode,
+            newHash,
+            [Glob.Parse(Path.Combine(RepoRoot, DuplicateOutputPath))]);
+
+        Assert.AreSame(currentNode, outputProducer[UniqueOutputPath]);
+        Assert.AreSame(previousNode, outputProducer[DuplicateOutputPath]);
+        Assert.AreSame(currentNode, outputProducer[TrailingUniqueOutputPath]);
+        Assert.HasCount(2, logger.LogEntries);
+        Assert.AreEqual(PluginLogLevel.Error, logger.LogEntries[1].LogLevel);
+        StringAssert.Contains(logger.LogEntries[1].Message, "with a different hash", StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public void CheckForDuplicateOutputsAllowsOrderedIdenticalDuplicateAfterUniqueOutput()
+    {
+        ContentHash hash = ContentHash.Random();
+        NodeContext previousNode = CreateNode("previous.proj");
+        previousNode.SetBuildResult(CreateBuildResult(hash));
+        NodeContext currentNode = CreateNode("current.proj", [previousNode]);
+        ConcurrentDictionary<string, NodeContext> outputProducer = CreateOutputProducer(previousNode);
+        MockPluginLogger logger = new();
+
+        CheckForDuplicateOutputs(
+            logger,
+            outputProducer,
+            currentNode,
+            hash,
+            [Glob.Parse(Path.Combine(RepoRoot, DuplicateOutputPath))]);
+
+        Assert.AreSame(currentNode, outputProducer[UniqueOutputPath]);
+        Assert.AreSame(previousNode, outputProducer[DuplicateOutputPath]);
+        Assert.AreSame(currentNode, outputProducer[TrailingUniqueOutputPath]);
+        Assert.HasCount(2, logger.LogEntries);
+        Assert.AreEqual(PluginLogLevel.Message, logger.LogEntries[1].LogLevel);
+        StringAssert.Contains(logger.LogEntries[1].Message, "Allowing as content is the same", StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public void CheckForDuplicateOutputsWarnsForUnorderedIdenticalDuplicateAfterUniqueOutput()
+    {
+        ContentHash hash = ContentHash.Random();
+        NodeContext previousNode = CreateNode("previous.proj");
+        previousNode.SetBuildResult(CreateBuildResult(hash));
+        NodeContext currentNode = CreateNode("current.proj");
+        ConcurrentDictionary<string, NodeContext> outputProducer = CreateOutputProducer(previousNode);
+        MockPluginLogger logger = new();
+
+        CheckForDuplicateOutputs(
+            logger,
+            outputProducer,
+            currentNode,
+            hash,
+            [Glob.Parse(Path.Combine(RepoRoot, DuplicateOutputPath))]);
+
+        Assert.AreSame(currentNode, outputProducer[UniqueOutputPath]);
+        Assert.AreSame(previousNode, outputProducer[DuplicateOutputPath]);
+        Assert.AreSame(currentNode, outputProducer[TrailingUniqueOutputPath]);
+        Assert.HasCount(2, logger.LogEntries);
+        Assert.AreEqual(PluginLogLevel.Warning, logger.LogEntries[1].LogLevel);
+        StringAssert.Contains(logger.LogEntries[1].Message, "there is no ordering between the two nodes", StringComparison.Ordinal);
+    }
+
+    private static void CheckForDuplicateOutputs(
+        MockPluginLogger logger,
+        ConcurrentDictionary<string, NodeContext> outputProducer,
+        NodeContext currentNode,
+        ContentHash duplicateOutputHash,
+        IReadOnlyCollection<Glob> identicalDuplicateOutputPatterns)
+    {
+        SortedDictionary<string, ContentHash> outputs = new(StringComparer.OrdinalIgnoreCase)
+        {
+            [UniqueOutputPath] = ContentHash.Random(),
+            [DuplicateOutputPath] = duplicateOutputHash,
+            [TrailingUniqueOutputPath] = ContentHash.Random(),
+        };
+
+        MSBuildCachePluginBase<PluginSettings>.CheckForDuplicateOutputs(
+            logger,
+            outputs,
+            currentNode,
+            outputProducer,
+            RepoRoot,
+            identicalDuplicateOutputPatterns);
+    }
+
+    private static ConcurrentDictionary<string, NodeContext> CreateOutputProducer(NodeContext previousNode)
+        => new(StringComparer.OrdinalIgnoreCase)
+        {
+            [DuplicateOutputPath] = previousNode,
+        };
+
+    private static NodeBuildResult CreateBuildResult(ContentHash duplicateOutputHash)
+        => new(
+            new SortedDictionary<string, ContentHash>(StringComparer.OrdinalIgnoreCase)
+            {
+                [DuplicateOutputPath] = duplicateOutputHash,
+            },
+            new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Array.Empty<NodeTargetResult>(),
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            null);
+
+    private static NodeContext CreateNode(string projectFileRelativePath, IReadOnlyList<NodeContext>? dependencies = null)
+        => new(
+            RepoRoot,
+            new ProjectInstance(ProjectRootElement.Create()),
+            dependencies ?? Array.Empty<NodeContext>(),
+            projectFileRelativePath,
+            new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            Array.Empty<string>(),
+            null,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+}

--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -1201,10 +1201,16 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
     }
 
     private bool IsDuplicateIdenticalOutputPath(PluginLoggerBase logger, string absolutePath)
+        => IsDuplicateIdenticalOutputPath(logger, absolutePath, _identicalDuplicateOutputPatterns);
+
+    private static bool IsDuplicateIdenticalOutputPath(
+        PluginLoggerBase logger,
+        string absolutePath,
+        IReadOnlyCollection<Glob>? identicalDuplicateOutputPatterns)
     {
-        if (_identicalDuplicateOutputPatterns != null && _identicalDuplicateOutputPatterns.Count > 0)
+        if (identicalDuplicateOutputPatterns != null && identicalDuplicateOutputPatterns.Count > 0)
         {
-            foreach (Glob pattern in _identicalDuplicateOutputPatterns)
+            foreach (Glob pattern in identicalDuplicateOutputPatterns)
             {
                 if (pattern.IsMatch(absolutePath))
                 {
@@ -1218,32 +1224,47 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
     }
 
     private void CheckForDuplicateOutputs(PluginLoggerBase logger, IReadOnlyDictionary<string, ContentHash> relativeFilePathToHash, NodeContext nodeContext)
+        => CheckForDuplicateOutputs(
+            logger,
+            relativeFilePathToHash,
+            nodeContext,
+            _outputProducer,
+            _repoRoot!,
+            _identicalDuplicateOutputPatterns);
+
+    internal static void CheckForDuplicateOutputs(
+        PluginLoggerBase logger,
+        IReadOnlyDictionary<string, ContentHash> relativeFilePathToHash,
+        NodeContext nodeContext,
+        ConcurrentDictionary<string, NodeContext> outputProducer,
+        string repoRoot,
+        IReadOnlyCollection<Glob>? identicalDuplicateOutputPatterns)
     {
         foreach (KeyValuePair<string, ContentHash> kvp in relativeFilePathToHash)
         {
             string relativeFilePath = kvp.Key;
             ContentHash newHash = kvp.Value;
 
-            // If this is the first writer to this path, then we are done.
-            NodeContext previousNode = _outputProducer.GetOrAdd(relativeFilePath, nodeContext);
+            // If this is the first writer to this path, then we are done with this output.
+            NodeContext previousNode = outputProducer.GetOrAdd(relativeFilePath, nodeContext);
             if (previousNode == nodeContext)
             {
-                return;
+                continue;
             }
 
             // This is only allowed if marked as a duplicate-identical output
-            string absoluteFilePath = Path.Combine(_repoRoot!, relativeFilePath);
-            if (!IsDuplicateIdenticalOutputPath(logger, absoluteFilePath))
+            string absoluteFilePath = Path.Combine(repoRoot, relativeFilePath);
+            if (!IsDuplicateIdenticalOutputPath(logger, absoluteFilePath, identicalDuplicateOutputPatterns))
             {
-                logger.LogError($"Node {nodeContext.Id} produced output {relativeFilePath} which was already produced by another node {_outputProducer[relativeFilePath].Id}.");
-                return;
+                logger.LogError($"Node {nodeContext.Id} produced output {relativeFilePath} which was already produced by another node {outputProducer[relativeFilePath].Id}.");
+                continue;
             }
 
             // This should never happen as the previous node is a dependent of this node...
             if (previousNode.BuildResult == null)
             {
                 logger.LogError($"Node {nodeContext.Id} produced output {relativeFilePath} which was already produced by another node {previousNode.Id}, however the hash of that first output is unknown.");
-                return;
+                continue;
             }
 
             // compare the hash of the original output to this output and log/error accordingly.
@@ -1251,14 +1272,14 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
             if (previousHash != newHash)
             {
                 logger.LogError($"Node {nodeContext.Id} produced output {relativeFilePath} with hash {newHash} which was already produced by another node {previousNode.Id} with a different hash {previousHash}.");
-                return;
+                continue;
             }
 
             // Duplicate-identical outputs are only allowed if there is a strict ordering between the multiple writers.
             if (!nodeContext.IsDependentOn(previousNode))
             {
                 logger.LogWarning($"Node {nodeContext.Id} produced output {relativeFilePath} which was already produced by another node {previousNode.Id}, but there is no ordering between the two nodes.");
-                return;
+                continue;
             }
 
             logger.LogMessage($"Node {nodeContext.Id} produced duplicate-identical output {relativeFilePath} which was already produced by another node {previousNode.Id}. Allowing as content is the same.");


### PR DESCRIPTION
A project with multiple outputs currently stops duplicate-producer registration after the first unseen path. As a result, later conflicts can go undetected on both cache-hit and completed-build paths.

## Changes

- Continue examining every output after first producers, conflicts, unknown hashes, and ordering warnings.
- Preserve the original producer and existing duplicate-identical content and dependency-order behavior.
- Add regressions with unique outputs before and after later conflicting, ordered-identical, and unordered-identical duplicates.

## Tests

- `Common.Tests` on `net9.0`: 140 passed
- Duplicate-output regressions on `net472`: 3 passed

Fixes: #165