### PR TITLE
Materialize recursively memoized cache hits on direct query

### DIFF
--- a/src/Common.Tests/Caching/CacheQueryResultTests.cs
+++ b/src/Common.Tests/Caching/CacheQueryResultTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.MSBuildCache.Caching;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.MSBuildCache.Tests.Caching;
+
+[TestClass]
+public sealed class CacheQueryResultTests
+{
+    [TestMethod]
+    public async Task MaterializeOutputsAsyncSequentialCallsMaterializesOnce()
+    {
+        int materializationCount = 0;
+        CacheQueryResult result = new(
+            pathSet: null,
+            nodeBuildResult: null,
+            _ =>
+            {
+                Interlocked.Increment(ref materializationCount);
+                return Task.CompletedTask;
+            },
+            waitForMaterialization: true);
+
+        await result.MaterializeOutputsAsync(CancellationToken.None);
+        await result.MaterializeOutputsAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, materializationCount);
+    }
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public async Task MaterializeOutputsAsyncConcurrentCallsMaterializesOnce()
+    {
+        TaskCompletionSource<bool> materializationStarted = CreateGate();
+        TaskCompletionSource<bool> releaseMaterialization = CreateGate();
+        int materializationCount = 0;
+        CacheQueryResult result = new(
+            pathSet: null,
+            nodeBuildResult: null,
+            async _ =>
+            {
+                Interlocked.Increment(ref materializationCount);
+                materializationStarted.SetResult(true);
+                await releaseMaterialization.Task;
+            },
+            waitForMaterialization: true);
+
+        Task firstCall = result.MaterializeOutputsAsync(CancellationToken.None);
+        await materializationStarted.Task;
+        Task secondCall = result.MaterializeOutputsAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, materializationCount);
+
+        releaseMaterialization.SetResult(true);
+        await Task.WhenAll(firstCall, secondCall);
+
+        Assert.AreEqual(1, materializationCount);
+    }
+
+    private static TaskCompletionSource<bool> CreateGate()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/src/Common.Tests/RecursiveCacheResultProviderTests.cs
+++ b/src/Common.Tests/RecursiveCacheResultProviderTests.cs
@@ -1,0 +1,330 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Experimental.ProjectCache;
+using Microsoft.Build.Framework;
+using Microsoft.MSBuildCache.Caching;
+using Microsoft.MSBuildCache.Tests.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.MSBuildCache.Tests;
+
+[TestClass]
+public sealed class RecursiveCacheResultProviderTests
+{
+    [TestMethod]
+    public async Task ParentThenDependencyMaterializesDependencyOnceWithoutSecondLookup()
+    {
+        NodeContext dependency = CreateNode("dependency.proj");
+        NodeContext parent = CreateNode("parent.proj", dependencies: [dependency]);
+        int dependencyLookupCount = 0;
+        int dependencyMaterializationCount = 0;
+        int dependencySetBuildResultCount = 0;
+        int parentLookupCount = 0;
+        RecursiveCacheResultProvider provider = CreateProvider(async (nodeContext, materializeOutputs, _, _) =>
+        {
+            await Task.CompletedTask;
+            if (ReferenceEquals(nodeContext, dependency))
+            {
+                Assert.IsFalse(materializeOutputs);
+                Interlocked.Increment(ref dependencyLookupCount);
+                return CreateCacheHit(
+                    dependency,
+                    () => Interlocked.Increment(ref dependencySetBuildResultCount),
+                    () => Interlocked.Increment(ref dependencyMaterializationCount));
+            }
+
+            Assert.IsTrue(materializeOutputs);
+            Interlocked.Increment(ref parentLookupCount);
+            return CreateCacheHit(parent);
+        });
+
+        CacheResult parentResult = await provider.GetCacheResultAsync(
+            parent,
+            materializeOutputs: true,
+            NullPluginLogger.Instance,
+            CancellationToken.None);
+
+        Assert.AreEqual(CacheResultType.CacheHit, parentResult.ResultType);
+        Assert.AreEqual(1, dependencyLookupCount);
+        Assert.AreEqual(1, dependencySetBuildResultCount);
+        Assert.AreEqual(0, dependencyMaterializationCount);
+        Assert.AreEqual(1, parentLookupCount);
+
+        CacheResult dependencyResult = await provider.GetCacheResultAsync(
+            dependency,
+            materializeOutputs: true,
+            NullPluginLogger.Instance,
+            CancellationToken.None);
+
+        Assert.AreEqual(CacheResultType.CacheHit, dependencyResult.ResultType);
+        Assert.AreEqual(1, dependencyLookupCount);
+        Assert.AreEqual(1, dependencySetBuildResultCount);
+        Assert.AreEqual(1, dependencyMaterializationCount);
+        Assert.AreEqual(1, parentLookupCount);
+
+        await provider.GetCacheResultAsync(
+            dependency,
+            materializeOutputs: true,
+            NullPluginLogger.Instance,
+            CancellationToken.None);
+
+        Assert.AreEqual(1, dependencyLookupCount);
+        Assert.AreEqual(1, dependencySetBuildResultCount);
+        Assert.AreEqual(1, dependencyMaterializationCount);
+    }
+
+    [TestMethod]
+    [Timeout(30_000)]
+    public async Task ConcurrentParentAndDependencyMaterializeAndLookupDependencyOnce()
+    {
+        NodeContext dependency = CreateNode("dependency.proj");
+        NodeContext parent = CreateNode("parent.proj", dependencies: [dependency]);
+        TaskCompletionSource<bool> dependencyLookupStarted = CreateGate();
+        TaskCompletionSource<bool> releaseDependencyLookup = CreateGate();
+        TaskCompletionSource<bool> dependencyMaterializationStarted = CreateGate();
+        TaskCompletionSource<bool> releaseDependencyMaterialization = CreateGate();
+        int dependencyLookupCount = 0;
+        int dependencyMaterializationCount = 0;
+        int dependencySetBuildResultCount = 0;
+        int parentLookupCount = 0;
+        RecursiveCacheResultProvider provider = CreateProvider(async (nodeContext, materializeOutputs, _, _) =>
+        {
+            if (ReferenceEquals(nodeContext, dependency))
+            {
+                Assert.IsFalse(materializeOutputs);
+                Interlocked.Increment(ref dependencyLookupCount);
+                dependencyLookupStarted.SetResult(true);
+                await releaseDependencyLookup.Task;
+
+                return CreateCacheHit(
+                    dependency,
+                    () => Interlocked.Increment(ref dependencySetBuildResultCount),
+                    async () =>
+                    {
+                        Interlocked.Increment(ref dependencyMaterializationCount);
+                        dependencyMaterializationStarted.SetResult(true);
+                        await releaseDependencyMaterialization.Task;
+                    });
+            }
+
+            Assert.IsTrue(materializeOutputs);
+            Interlocked.Increment(ref parentLookupCount);
+            return CreateCacheHit(parent);
+        });
+
+        Task<CacheResult> parentQuery = provider.GetCacheResultAsync(
+            parent,
+            materializeOutputs: true,
+            NullPluginLogger.Instance,
+            CancellationToken.None);
+        await dependencyLookupStarted.Task;
+
+        Task<CacheResult> dependencyQuery = provider.GetCacheResultAsync(
+            dependency,
+            materializeOutputs: true,
+            NullPluginLogger.Instance,
+            CancellationToken.None);
+
+        Assert.AreEqual(1, dependencyLookupCount);
+
+        releaseDependencyLookup.SetResult(true);
+        await dependencyMaterializationStarted.Task;
+
+        Assert.AreEqual(1, dependencyLookupCount);
+        Assert.AreEqual(1, dependencySetBuildResultCount);
+        Assert.AreEqual(1, dependencyMaterializationCount);
+
+        releaseDependencyMaterialization.SetResult(true);
+        CacheResult[] results = await Task.WhenAll(parentQuery, dependencyQuery);
+
+        Assert.AreEqual(CacheResultType.CacheHit, results[0].ResultType);
+        Assert.AreEqual(CacheResultType.CacheHit, results[1].ResultType);
+        Assert.AreEqual(1, dependencyLookupCount);
+        Assert.AreEqual(1, dependencySetBuildResultCount);
+        Assert.AreEqual(1, dependencyMaterializationCount);
+        Assert.AreEqual(1, parentLookupCount);
+    }
+
+    [TestMethod]
+    public async Task OuterBuildThenInnerBuildMaterializesInnerBuildOnce()
+    {
+        NodeContext innerBuild = CreateNode("multitargeting.proj", CreateInnerBuildProject());
+        NodeContext outerBuild = CreateNode(
+            "multitargeting.proj",
+            CreateOuterBuildProject(),
+            [innerBuild]);
+        int innerLookupCount = 0;
+        int innerMaterializationCount = 0;
+        int innerSetBuildResultCount = 0;
+        int outerLookupCount = 0;
+        RecursiveCacheResultProvider provider = CreateProvider((nodeContext, materializeOutputs, _, _) =>
+        {
+            if (ReferenceEquals(nodeContext, innerBuild))
+            {
+                Assert.IsTrue(materializeOutputs);
+                Interlocked.Increment(ref innerLookupCount);
+                return Task.FromResult(CreateCacheHit(
+                    innerBuild,
+                    () => Interlocked.Increment(ref innerSetBuildResultCount),
+                    () => Interlocked.Increment(ref innerMaterializationCount)));
+            }
+
+            Assert.IsTrue(materializeOutputs);
+            Interlocked.Increment(ref outerLookupCount);
+            return Task.FromResult(CreateCacheHit(outerBuild));
+        });
+
+        CacheResult outerResult = await provider.GetCacheResultAsync(
+            outerBuild,
+            materializeOutputs: true,
+            NullPluginLogger.Instance,
+            CancellationToken.None);
+
+        Assert.AreEqual(CacheResultType.CacheHit, outerResult.ResultType);
+        Assert.AreEqual(1, innerLookupCount);
+        Assert.AreEqual(1, innerSetBuildResultCount);
+        Assert.AreEqual(1, innerMaterializationCount);
+        Assert.AreEqual(1, outerLookupCount);
+
+        CacheResult innerResult = await provider.GetCacheResultAsync(
+            innerBuild,
+            materializeOutputs: true,
+            NullPluginLogger.Instance,
+            CancellationToken.None);
+
+        Assert.AreEqual(CacheResultType.CacheHit, innerResult.ResultType);
+        Assert.AreEqual(1, innerLookupCount);
+        Assert.AreEqual(1, innerSetBuildResultCount);
+        Assert.AreEqual(1, innerMaterializationCount);
+        Assert.AreEqual(1, outerLookupCount);
+    }
+
+    [TestMethod]
+    public async Task DependencyCacheMissDoesNotQueryParent()
+    {
+        NodeContext dependency = CreateNode("dependency.proj");
+        NodeContext parent = CreateNode("parent.proj", dependencies: [dependency]);
+        int dependencyLookupCount = 0;
+        int dependencyCacheMissCount = 0;
+        int parentLookupCount = 0;
+        RecursiveCacheResultProvider provider = CreateProvider(
+            (nodeContext, materializeOutputs, _, _) =>
+            {
+                if (ReferenceEquals(nodeContext, dependency))
+                {
+                    Assert.IsFalse(materializeOutputs);
+                    Interlocked.Increment(ref dependencyLookupCount);
+                    return Task.FromResult(new NodeCacheResult(
+                        CacheResult.IndicateNonCacheHit(CacheResultType.CacheMiss),
+                        null));
+                }
+
+                Interlocked.Increment(ref parentLookupCount);
+                return Task.FromResult(CreateCacheHit(parent));
+            },
+            () => Interlocked.Increment(ref dependencyCacheMissCount));
+
+        CacheResult result = await provider.GetCacheResultAsync(
+            parent,
+            materializeOutputs: true,
+            NullPluginLogger.Instance,
+            CancellationToken.None);
+
+        Assert.AreEqual(CacheResultType.CacheMiss, result.ResultType);
+        Assert.AreEqual(1, dependencyLookupCount);
+        Assert.AreEqual(1, dependencyCacheMissCount);
+        Assert.AreEqual(0, parentLookupCount);
+    }
+
+    private static RecursiveCacheResultProvider CreateProvider(
+        Func<NodeContext, bool, PluginLoggerBase, CancellationToken, Task<NodeCacheResult>> getCacheResultAsync,
+        Action? recordDependencyCacheMiss = null)
+        => new(2, getCacheResultAsync, recordDependencyCacheMiss ?? (() => { }));
+
+    private static NodeCacheResult CreateCacheHit(
+        NodeContext nodeContext,
+        Action? setBuildResult = null,
+        Func<Task>? materializeOutputsAsync = null)
+    {
+        NodeBuildResult buildResult = new(
+            new SortedDictionary<string, BuildXL.Cache.ContentStore.Hashing.ContentHash>(),
+            new SortedDictionary<string, string>(),
+            [new NodeTargetResult("Build", Array.Empty<NodeTargetResultTaskItem>())],
+            new DateTime(1970, 1, 1),
+            new DateTime(1970, 1, 1),
+            buildId: null);
+        setBuildResult?.Invoke();
+        nodeContext.SetBuildResult(buildResult);
+
+        CacheQueryResult queryResult = new(
+            pathSet: null,
+            buildResult,
+            materializeOutputsAsync is null ? null : _ => materializeOutputsAsync(),
+            waitForMaterialization: true);
+        return new NodeCacheResult(
+            CacheResult.IndicateCacheHit(
+                [new PluginTargetResult("Build", Array.Empty<ITaskItem2>(), BuildResultCode.Success)]),
+            queryResult);
+    }
+
+    private static NodeCacheResult CreateCacheHit(
+        NodeContext nodeContext,
+        Action? setBuildResult,
+        Action materializeOutputs)
+        => CreateCacheHit(
+            nodeContext,
+            setBuildResult,
+            () =>
+            {
+                materializeOutputs();
+                return Task.CompletedTask;
+            });
+
+    private static NodeContext CreateNode(
+        string projectFileRelativePath,
+        ProjectInstance? projectInstance = null,
+        IReadOnlyList<NodeContext>? dependencies = null)
+        => new(
+            baseLogDirectory: string.Empty,
+            projectInstance ?? CreateProjectInstance(),
+            dependencies ?? Array.Empty<NodeContext>(),
+            projectFileRelativePath,
+            new SortedDictionary<string, string>(),
+            Array.Empty<string>(),
+            referenceAssemblyRelativePath: null,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+    private static ProjectInstance CreateProjectInstance(params (string Name, string Value)[] properties)
+    {
+        ProjectRootElement project = ProjectRootElement.Create();
+        foreach ((string name, string value) in properties)
+        {
+            project.AddProperty(name, value);
+        }
+
+        return new ProjectInstance(project);
+    }
+
+    private static ProjectInstance CreateOuterBuildProject()
+        => CreateProjectInstance(
+            ("InnerBuildProperty", "TargetFramework"),
+            ("InnerBuildPropertyValues", "TargetFrameworks"),
+            ("TargetFrameworks", "net8.0;net9.0"));
+
+    private static ProjectInstance CreateInnerBuildProject()
+        => CreateProjectInstance(
+            ("InnerBuildProperty", "TargetFramework"),
+            ("InnerBuildPropertyValues", "TargetFrameworks"),
+            ("TargetFrameworks", "net8.0;net9.0"),
+            ("TargetFramework", "net9.0"));
+
+    private static TaskCompletionSource<bool> CreateGate()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/src/Common/Caching/CacheClient.cs
+++ b/src/Common/Caching/CacheClient.cs
@@ -28,12 +28,13 @@ using WeakFingerprint = BuildXL.Cache.MemoizationStore.Interfaces.Sessions.Finge
 
 namespace Microsoft.MSBuildCache.Caching;
 
-public abstract class CacheClient : ICacheClient
+public abstract class CacheClient : ICacheClient, IMaterializingCacheClient
 {
     private static readonly byte[] EmptySelectorOutput = new byte[1];
     private readonly OutputHasher _outputHasher;
     private readonly ConcurrentDictionary<NodeContext, Task> _publishingTasks = new();
     private readonly ConcurrentDictionary<NodeContext, Task> _materializationTasks = new();
+    private readonly ConcurrentDictionary<NodeContext, CacheQueryResult> _nodeQueryResults = new();
     private readonly ConcurrentDictionary<string, bool> _directoryCreationCache = new();
     private readonly ConcurrentDictionary<string, Lazy<Task<string>>> _placeFromPackageCache = new(StringComparer.OrdinalIgnoreCase);
     private readonly ICopyOnWriteFilesystem _copyOnWriteFilesystem = CopyOnWriteFilesystemFactory.GetInstance();
@@ -363,16 +364,38 @@ public abstract class CacheClient : ICacheClient
         bool materializeOutputs,
         CancellationToken cancellationToken)
     {
-        (PathSet? PathSet, NodeBuildResult? NodeBuildResult) result = await GetNodeInternalAsync(nodeContext, materializeOutputs, cancellationToken);
+        CacheQueryResult result = await QueryNodeAsync(nodeContext, cancellationToken);
+        return await CompleteQueryAsync(result, materializeOutputs, cancellationToken);
+    }
+
+    public async Task<(PathSet?, NodeBuildResult?)> GetNodeInternalAsync(
+        NodeContext nodeContext,
+        bool materializeOutputs,
+        CancellationToken cancellationToken)
+    {
+        CacheQueryResult result = await QueryNodeInternalAsync(nodeContext, cancellationToken);
+        return await CompleteQueryAsync(result, materializeOutputs, cancellationToken);
+    }
+
+    Task<CacheQueryResult> IMaterializingCacheClient.QueryNodeAsync(
+        NodeContext nodeContext,
+        CancellationToken cancellationToken)
+        => QueryNodeAsync(nodeContext, cancellationToken);
+
+    private async Task<CacheQueryResult> QueryNodeAsync(
+        NodeContext nodeContext,
+        CancellationToken cancellationToken)
+    {
+        CacheQueryResult result = await QueryNodeInternalAsync(nodeContext, cancellationToken);
 
         // On cache miss ensure all dependencies are materialized before returning to MSBuild so that MSBuild's execution will actually work.
-        if (_enableAsyncMaterialization && result.NodeBuildResult == null)
+        if (result.NodeBuildResult == null)
         {
             foreach (NodeContext dependency in nodeContext.Dependencies)
             {
-                if (_materializationTasks.TryGetValue(dependency, out Task? dependencyMaterializationTask))
+                if (_nodeQueryResults.TryGetValue(dependency, out CacheQueryResult? dependencyResult))
                 {
-                    await dependencyMaterializationTask;
+                    await dependencyResult.EnsureOutputsMaterializedAsync(cancellationToken);
                 }
             }
         }
@@ -380,9 +403,8 @@ public abstract class CacheClient : ICacheClient
         return result;
     }
 
-    public async Task<(PathSet?, NodeBuildResult?)> GetNodeInternalAsync(
+    private async Task<CacheQueryResult> QueryNodeInternalAsync(
         NodeContext nodeContext,
-        bool materializeOutputs,
         CancellationToken cancellationToken)
     {
         Context context = new(RootContext);
@@ -393,7 +415,7 @@ public abstract class CacheClient : ICacheClient
         if (weakFingerprint == null)
         {
             Tracer.Debug(context, $"Weak fingerprint is null for {nodeContext.Id}");
-            return (null, null);
+            return new CacheQueryResult(null, null, null, waitForMaterialization: true);
         }
 
         WeakFingerprint cacheWeakFingerprint = new(weakFingerprint.Hash);
@@ -402,7 +424,7 @@ public abstract class CacheClient : ICacheClient
         if (!selector.HasValue)
         {
             // GetMatchingSelectorAsync logs sufficiently
-            return (null, null);
+            return new CacheQueryResult(null, null, null, waitForMaterialization: true);
         }
 
         StrongFingerprint cacheStrongFingerprint = new(cacheWeakFingerprint, selector.Value);
@@ -411,14 +433,14 @@ public abstract class CacheClient : ICacheClient
         if (cacheEntry is null)
         {
             Tracer.Debug(context, $"{nameof(GetCacheEntryAsync)} did not find an entry for {cacheStrongFingerprint}.");
-            return (null, null);
+            return new CacheQueryResult(null, null, null, waitForMaterialization: true);
         }
 
         using Stream? nodeBuildResultStream = await cacheEntry.GetNodeBuildResultAsync(context, cancellationToken);
         if (nodeBuildResultStream is null)
         {
             Tracer.Debug(context, $"Failed to fetch NodeBuildResult for {cacheStrongFingerprint}");
-            return (null, null);
+            return new CacheQueryResult(null, null, null, waitForMaterialization: true);
         }
 
         // The first file is special: it is a serialized NodeBuildResult file.
@@ -426,7 +448,7 @@ public abstract class CacheClient : ICacheClient
         if (nodeBuildResult is null)
         {
             Tracer.Debug(context, $"Failed to deserialize NodeBuildResult for {cacheStrongFingerprint}");
-            return (null, null);
+            return new CacheQueryResult(null, null, null, waitForMaterialization: true);
         }
 
         async Task CopyPackageContentToDestinationAsync(string sourceAbsolutePath, string destinationAbsolutePath)
@@ -523,29 +545,39 @@ public abstract class CacheClient : ICacheClient
             }
         }
 
-        if (materializeOutputs)
+        Task MaterializeOutputsAsync(CancellationToken ct)
         {
             if (_enableAsyncMaterialization)
             {
-                _materializationTasks.TryAdd(
-                    nodeContext,
-                    // Avoid using a cancellation token since MSBuild will cancel it when it thinks the build is finished and we await these tasks at that point.
-                    // Note that this means that we effectively cannot cancel this operation once started and the user will have to wait.
-                    Task.Run(
-                        async () =>
-                        {
-                            await PlaceFilesAsync(CancellationToken.None);
-                            _materializationTasks.TryRemove(nodeContext, out _);
-                        },
-                        CancellationToken.None));
+                // Avoid using a cancellation token since MSBuild will cancel it when it thinks the build is finished and we await these tasks at that point.
+                // Note that this means that we effectively cannot cancel this operation once started and the user will have to wait.
+                Task materializationTask = Task.Run(() => PlaceFilesAsync(CancellationToken.None), CancellationToken.None);
+                _materializationTasks.TryAdd(nodeContext, materializationTask);
+                return materializationTask;
             }
-            else
-            {
-                await PlaceFilesAsync(cancellationToken);
-            }
+
+            return PlaceFilesAsync(ct);
         }
 
-        return (pathSet, nodeBuildResult);
+        CacheQueryResult queryResult = new(
+            pathSet,
+            nodeBuildResult,
+            MaterializeOutputsAsync,
+            waitForMaterialization: !_enableAsyncMaterialization);
+        return _nodeQueryResults.GetOrAdd(nodeContext, queryResult);
+    }
+
+    private static async Task<(PathSet?, NodeBuildResult?)> CompleteQueryAsync(
+        CacheQueryResult result,
+        bool materializeOutputs,
+        CancellationToken cancellationToken)
+    {
+        if (materializeOutputs && result.NodeBuildResult is not null)
+        {
+            await result.MaterializeOutputsAsync(cancellationToken);
+        }
+
+        return (result.PathSet, result.NodeBuildResult);
     }
 
     private async Task<(Selector? Selector, PathSet? PathSet)> GetMatchingSelectorAsync(

--- a/src/Common/Caching/CacheClient.cs
+++ b/src/Common/Caching/CacheClient.cs
@@ -28,7 +28,7 @@ using WeakFingerprint = BuildXL.Cache.MemoizationStore.Interfaces.Sessions.Finge
 
 namespace Microsoft.MSBuildCache.Caching;
 
-public abstract class CacheClient : ICacheClient, IMaterializingCacheClient
+public abstract class CacheClient : ICacheClient
 {
     private static readonly byte[] EmptySelectorOutput = new byte[1];
     private readonly OutputHasher _outputHasher;
@@ -359,34 +359,11 @@ public abstract class CacheClient : ICacheClient, IMaterializingCacheClient
         }
     }
 
-    public async Task<(PathSet?, NodeBuildResult?)> GetNodeAsync(
-        NodeContext nodeContext,
-        bool materializeOutputs,
-        CancellationToken cancellationToken)
-    {
-        CacheQueryResult result = await QueryNodeAsync(nodeContext, cancellationToken);
-        return await CompleteQueryAsync(result, materializeOutputs, cancellationToken);
-    }
-
-    public async Task<(PathSet?, NodeBuildResult?)> GetNodeInternalAsync(
-        NodeContext nodeContext,
-        bool materializeOutputs,
-        CancellationToken cancellationToken)
-    {
-        CacheQueryResult result = await QueryNodeInternalAsync(nodeContext, cancellationToken);
-        return await CompleteQueryAsync(result, materializeOutputs, cancellationToken);
-    }
-
-    Task<CacheQueryResult> IMaterializingCacheClient.QueryNodeAsync(
-        NodeContext nodeContext,
-        CancellationToken cancellationToken)
-        => QueryNodeAsync(nodeContext, cancellationToken);
-
-    private async Task<CacheQueryResult> QueryNodeAsync(
+    public async Task<CacheQueryResult> GetNodeAsync(
         NodeContext nodeContext,
         CancellationToken cancellationToken)
     {
-        CacheQueryResult result = await QueryNodeInternalAsync(nodeContext, cancellationToken);
+        CacheQueryResult result = await GetNodeInternalAsync(nodeContext, cancellationToken);
 
         // On cache miss ensure all dependencies are materialized before returning to MSBuild so that MSBuild's execution will actually work.
         if (result.NodeBuildResult == null)
@@ -403,7 +380,7 @@ public abstract class CacheClient : ICacheClient, IMaterializingCacheClient
         return result;
     }
 
-    private async Task<CacheQueryResult> QueryNodeInternalAsync(
+    public async Task<CacheQueryResult> GetNodeInternalAsync(
         NodeContext nodeContext,
         CancellationToken cancellationToken)
     {
@@ -565,19 +542,6 @@ public abstract class CacheClient : ICacheClient, IMaterializingCacheClient
             MaterializeOutputsAsync,
             waitForMaterialization: !_enableAsyncMaterialization);
         return _nodeQueryResults.GetOrAdd(nodeContext, queryResult);
-    }
-
-    private static async Task<(PathSet?, NodeBuildResult?)> CompleteQueryAsync(
-        CacheQueryResult result,
-        bool materializeOutputs,
-        CancellationToken cancellationToken)
-    {
-        if (materializeOutputs && result.NodeBuildResult is not null)
-        {
-            await result.MaterializeOutputsAsync(cancellationToken);
-        }
-
-        return (result.PathSet, result.NodeBuildResult);
     }
 
     private async Task<(Selector? Selector, PathSet? PathSet)> GetMatchingSelectorAsync(

--- a/src/Common/Caching/CacheQueryResult.cs
+++ b/src/Common/Caching/CacheQueryResult.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.MSBuildCache.Fingerprinting;
+
+namespace Microsoft.MSBuildCache.Caching;
+
+internal interface IMaterializingCacheClient
+{
+    Task<CacheQueryResult> QueryNodeAsync(NodeContext nodeContext, CancellationToken cancellationToken);
+}
+
+internal sealed class CacheQueryResult
+{
+    private readonly object _materializationLock = new();
+    private readonly Func<CancellationToken, Task>? _materializeOutputsAsync;
+    private readonly bool _waitForMaterialization;
+    private Task? _materializationTask;
+
+    internal CacheQueryResult(
+        PathSet? pathSet,
+        NodeBuildResult? nodeBuildResult,
+        Func<CancellationToken, Task>? materializeOutputsAsync,
+        bool waitForMaterialization)
+    {
+        PathSet = pathSet;
+        NodeBuildResult = nodeBuildResult;
+        _materializeOutputsAsync = materializeOutputsAsync;
+        _waitForMaterialization = waitForMaterialization;
+    }
+
+    public PathSet? PathSet { get; }
+
+    public NodeBuildResult? NodeBuildResult { get; }
+
+    public Task MaterializeOutputsAsync(CancellationToken cancellationToken)
+    {
+        Task materializationTask = EnsureOutputsMaterializedAsync(cancellationToken);
+        return _waitForMaterialization ? materializationTask : Task.CompletedTask;
+    }
+
+    internal Task EnsureOutputsMaterializedAsync(CancellationToken cancellationToken)
+    {
+        if (_materializeOutputsAsync is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        lock (_materializationLock)
+        {
+            return _materializationTask ??= _materializeOutputsAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Common/Caching/CacheQueryResult.cs
+++ b/src/Common/Caching/CacheQueryResult.cs
@@ -8,19 +8,14 @@ using Microsoft.MSBuildCache.Fingerprinting;
 
 namespace Microsoft.MSBuildCache.Caching;
 
-internal interface IMaterializingCacheClient
-{
-    Task<CacheQueryResult> QueryNodeAsync(NodeContext nodeContext, CancellationToken cancellationToken);
-}
-
-internal sealed class CacheQueryResult
+public sealed class CacheQueryResult
 {
     private readonly object _materializationLock = new();
     private readonly Func<CancellationToken, Task>? _materializeOutputsAsync;
     private readonly bool _waitForMaterialization;
     private Task? _materializationTask;
 
-    internal CacheQueryResult(
+    public CacheQueryResult(
         PathSet? pathSet,
         NodeBuildResult? nodeBuildResult,
         Func<CancellationToken, Task>? materializeOutputsAsync,

--- a/src/Common/Caching/ICacheClient.cs
+++ b/src/Common/Caching/ICacheClient.cs
@@ -19,7 +19,7 @@ public interface ICacheClient : IAsyncDisposable
         Func<IReadOnlyDictionary<string, ContentHash>, NodeBuildResult> nodeBuildResultBuilder,
         CancellationToken cancellationToken);
 
-    Task<(PathSet?, NodeBuildResult?)> GetNodeAsync(NodeContext nodeContext, bool materializeOutputs, CancellationToken cancellationToken);
+    Task<CacheQueryResult> GetNodeAsync(NodeContext nodeContext, CancellationToken cancellationToken);
 
     Task ShutdownAsync(CancellationToken cancellationToken);
 }

--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -435,36 +435,7 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
 
         nodeContext.SetStartTime();
 
-        CacheQueryResult queryResult;
-        if (_cacheClient is IMaterializingCacheClient materializingCacheClient)
-        {
-            queryResult = await materializingCacheClient.QueryNodeAsync(nodeContext, cancellationToken);
-        }
-        else
-        {
-            (PathSet? legacyPathSet, NodeBuildResult? legacyBuildResult) = await _cacheClient.GetNodeAsync(
-                nodeContext,
-                materializeOutputs,
-                cancellationToken);
-
-            queryResult = new CacheQueryResult(
-                legacyPathSet,
-                legacyBuildResult,
-                materializeOutputs || legacyBuildResult is null ? null : MaterializeLegacyCacheResultAsync,
-                waitForMaterialization: true);
-
-            async Task MaterializeLegacyCacheResultAsync(CancellationToken ct)
-            {
-                (_, NodeBuildResult? materializedBuildResult) = await _cacheClient.GetNodeAsync(
-                    nodeContext,
-                    materializeOutputs: true,
-                    ct);
-                if (materializedBuildResult is null)
-                {
-                    throw new CacheException($"Failed to materialize the previously found cache result for {nodeContext.Id}.");
-                }
-            }
-        }
+        CacheQueryResult queryResult = await _cacheClient.GetNodeAsync(nodeContext, cancellationToken);
 
         PathSet? pathSet = queryResult.PathSet;
         NodeBuildResult? nodeBuildResult = queryResult.NodeBuildResult;
@@ -474,7 +445,7 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
             return new NodeCacheResult(CacheResult.IndicateNonCacheHit(CacheResultType.CacheMiss), queryResult);
         }
 
-        if (materializeOutputs && _cacheClient is IMaterializingCacheClient)
+        if (materializeOutputs)
         {
             await queryResult.MaterializeOutputsAsync(cancellationToken);
         }

--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -68,6 +68,7 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
     private SemaphoreSlim? _singlePluginInstanceMutex;
     private PathNormalizer? _pathNormalizer;
     private Func<NodeContext, PluginLoggerBase, CancellationToken, Task<CacheResult>>? _getCacheResultAsync;
+    private RecursiveCacheResultProvider? _recursiveCacheResultProvider;
 
     private int _cacheHitCount;
     private long _cacheHitDurationMilliseconds;
@@ -333,8 +334,12 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
 
         if (Settings.GetResultsForUnqueriedDependencies)
         {
-            ConcurrentDictionary<NodeContext, Lazy<Task<CacheResult>>> cacheResults = new(concurrencyLevel: Environment.ProcessorCount, _nodeContexts.Count);
-            _getCacheResultAsync = (nodeContext, logger, cancellationToken) => GetCacheResultRecursivelyAsync(cacheResults, nodeContext, materializeOutputs: true, logger, cancellationToken);
+            _recursiveCacheResultProvider = new RecursiveCacheResultProvider(
+                _nodeContexts.Count,
+                GetCacheResultSingleAsync,
+                () => Interlocked.Increment(ref _cacheMissCount));
+            _getCacheResultAsync = (nodeContext, logger, cancellationToken) =>
+                _recursiveCacheResultProvider.GetCacheResultAsync(nodeContext, materializeOutputs: true, logger, cancellationToken);
         }
         else
         {
@@ -402,48 +407,6 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
         return await _getCacheResultAsync(nodeContext, logger, cancellationToken);
     }
 
-    private async Task<CacheResult> GetCacheResultRecursivelyAsync(
-        ConcurrentDictionary<NodeContext, Lazy<Task<CacheResult>>> cacheResults,
-        NodeContext nodeContext,
-        bool materializeOutputs,
-        PluginLoggerBase logger,
-        CancellationToken cancellationToken)
-    {
-        // Ensure we only query a node exactly once. MSBuild won't query a project more than once, but when recursion is enabled,
-        // we might have multiple build requests querying the same unqueried dependency.
-        return await cacheResults.GetOrAdd(nodeContext, new Lazy<Task<CacheResult>>(
-            async () =>
-            {
-                bool isOuterBuild = nodeContext.ProjectInstance.IsOuterBuild();
-
-                foreach (NodeContext dependency in nodeContext.Dependencies)
-                {
-                    if (dependency.BuildResult == null)
-                    {
-                        // When querying recursively, avoid materializing the outputs. That node was never directly queried, so its outputs
-                        // are not desired from the caller. Note that there is an assumption that the node won't be queried directly later
-                        // as that would break the expected "bottom-up" build order of graph builds.
-                        // Special-case the outer build of a multitargeting project which dependencies on the inner builds for which we do
-                        // want the outputs.
-                        bool materializeOutputs = isOuterBuild && dependency.ProjectInstance.IsInnerBuild();
-
-                        logger.LogMessage($"Querying cache for missing build result for dependency '{dependency.Id}'");
-                        CacheResult dependencyResult = await GetCacheResultRecursivelyAsync(cacheResults, dependency, materializeOutputs, logger, cancellationToken);
-                        logger.LogMessage($"Dependency '{dependency.Id}' cache result: '{dependencyResult.ResultType}'");
-
-                        if (dependencyResult.ResultType != CacheResultType.CacheHit)
-                        {
-                            logger.LogMessage($"Cache miss due to failed build result for dependency '{dependency.Id}'");
-                            Interlocked.Increment(ref _cacheMissCount);
-                            return CacheResult.IndicateNonCacheHit(CacheResultType.CacheMiss);
-                        }
-                    }
-                }
-
-                return await GetCacheResultSingleAsync(nodeContext, materializeOutputs, logger, cancellationToken);
-            })).Value;
-    }
-
     private async Task<CacheResult> GetCacheResultNonRecursiveAsync(NodeContext nodeContext, PluginLoggerBase logger, CancellationToken cancellationToken)
     {
         foreach (NodeContext dependency in nodeContext.Dependencies)
@@ -456,10 +419,14 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
             }
         }
 
-        return await GetCacheResultSingleAsync(nodeContext, materializeOutputs: true, logger, cancellationToken);
+        return (await GetCacheResultSingleAsync(nodeContext, materializeOutputs: true, logger, cancellationToken)).Result;
     }
 
-    private async Task<CacheResult> GetCacheResultSingleAsync(NodeContext nodeContext, bool materializeOutputs, PluginLoggerBase logger, CancellationToken cancellationToken)
+    private async Task<NodeCacheResult> GetCacheResultSingleAsync(
+        NodeContext nodeContext,
+        bool materializeOutputs,
+        PluginLoggerBase logger,
+        CancellationToken cancellationToken)
     {
         if (!Initialized)
         {
@@ -468,11 +435,48 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
 
         nodeContext.SetStartTime();
 
-        (PathSet? pathSet, NodeBuildResult? nodeBuildResult) = await _cacheClient.GetNodeAsync(nodeContext, materializeOutputs, cancellationToken);
+        CacheQueryResult queryResult;
+        if (_cacheClient is IMaterializingCacheClient materializingCacheClient)
+        {
+            queryResult = await materializingCacheClient.QueryNodeAsync(nodeContext, cancellationToken);
+        }
+        else
+        {
+            (PathSet? legacyPathSet, NodeBuildResult? legacyBuildResult) = await _cacheClient.GetNodeAsync(
+                nodeContext,
+                materializeOutputs,
+                cancellationToken);
+
+            queryResult = new CacheQueryResult(
+                legacyPathSet,
+                legacyBuildResult,
+                materializeOutputs || legacyBuildResult is null ? null : MaterializeLegacyCacheResultAsync,
+                waitForMaterialization: true);
+
+            async Task MaterializeLegacyCacheResultAsync(CancellationToken ct)
+            {
+                (_, NodeBuildResult? materializedBuildResult) = await _cacheClient.GetNodeAsync(
+                    nodeContext,
+                    materializeOutputs: true,
+                    ct);
+                if (materializedBuildResult is null)
+                {
+                    throw new CacheException($"Failed to materialize the previously found cache result for {nodeContext.Id}.");
+                }
+            }
+        }
+
+        PathSet? pathSet = queryResult.PathSet;
+        NodeBuildResult? nodeBuildResult = queryResult.NodeBuildResult;
         if (nodeBuildResult is null)
         {
             Interlocked.Increment(ref _cacheMissCount);
-            return CacheResult.IndicateNonCacheHit(CacheResultType.CacheMiss);
+            return new NodeCacheResult(CacheResult.IndicateNonCacheHit(CacheResultType.CacheMiss), queryResult);
+        }
+
+        if (materializeOutputs && _cacheClient is IMaterializingCacheClient)
+        {
+            await queryResult.MaterializeOutputsAsync(cancellationToken);
         }
 
         CheckForDuplicateOutputs(logger, nodeBuildResult.Outputs, nodeContext);
@@ -481,7 +485,7 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
 
         Interlocked.Increment(ref _cacheHitCount);
         Interlocked.Add(ref _cacheHitDurationMilliseconds, (int)(nodeBuildResult.EndTimeUtc - nodeBuildResult.StartTimeUtc).TotalMilliseconds);
-        return nodeBuildResult.ToCacheResult(_pathNormalizer);
+        return new NodeCacheResult(nodeBuildResult.ToCacheResult(_pathNormalizer), queryResult);
     }
 
     public override void HandleFileAccess(FileAccessContext fileAccessContext, FileAccessData fileAccessData)

--- a/src/Common/RecursiveCacheResultProvider.cs
+++ b/src/Common/RecursiveCacheResultProvider.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Experimental.ProjectCache;
+using Microsoft.MSBuildCache.Caching;
+
+namespace Microsoft.MSBuildCache;
+
+internal sealed record NodeCacheResult(CacheResult Result, CacheQueryResult? QueryResult)
+{
+    public Task MaterializeOutputsAsync(CancellationToken cancellationToken)
+        => QueryResult?.MaterializeOutputsAsync(cancellationToken) ?? Task.CompletedTask;
+}
+
+internal sealed class RecursiveCacheResultProvider
+{
+    private readonly ConcurrentDictionary<NodeContext, Lazy<Task<NodeCacheResult>>> _cacheResults;
+    private readonly Func<NodeContext, bool, PluginLoggerBase, CancellationToken, Task<NodeCacheResult>> _getCacheResultSingleAsync;
+    private readonly Action _recordDependencyCacheMiss;
+
+    public RecursiveCacheResultProvider(
+        int nodeCount,
+        Func<NodeContext, bool, PluginLoggerBase, CancellationToken, Task<NodeCacheResult>> getCacheResultSingleAsync,
+        Action recordDependencyCacheMiss)
+    {
+        _cacheResults = new ConcurrentDictionary<NodeContext, Lazy<Task<NodeCacheResult>>>(Environment.ProcessorCount, nodeCount);
+        _getCacheResultSingleAsync = getCacheResultSingleAsync;
+        _recordDependencyCacheMiss = recordDependencyCacheMiss;
+    }
+
+    public async Task<CacheResult> GetCacheResultAsync(
+        NodeContext nodeContext,
+        bool materializeOutputs,
+        PluginLoggerBase logger,
+        CancellationToken cancellationToken)
+    {
+        NodeCacheResult result = await _cacheResults.GetOrAdd(
+            nodeContext,
+            new Lazy<Task<NodeCacheResult>>(
+                () => GetCacheResultWithDependenciesAsync(nodeContext, materializeOutputs, logger, cancellationToken),
+                LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+
+        if (materializeOutputs && result.Result.ResultType == CacheResultType.CacheHit)
+        {
+            await result.MaterializeOutputsAsync(cancellationToken);
+        }
+
+        return result.Result;
+    }
+
+    private async Task<NodeCacheResult> GetCacheResultWithDependenciesAsync(
+        NodeContext nodeContext,
+        bool materializeOutputs,
+        PluginLoggerBase logger,
+        CancellationToken cancellationToken)
+    {
+        bool isOuterBuild = nodeContext.ProjectInstance.IsOuterBuild();
+
+        foreach (NodeContext dependency in nodeContext.Dependencies)
+        {
+            if (dependency.BuildResult == null)
+            {
+                bool materializeDependencyOutputs = isOuterBuild && dependency.ProjectInstance.IsInnerBuild();
+
+                logger.LogMessage($"Querying cache for missing build result for dependency '{dependency.Id}'");
+                CacheResult dependencyResult = await GetCacheResultAsync(dependency, materializeDependencyOutputs, logger, cancellationToken);
+                logger.LogMessage($"Dependency '{dependency.Id}' cache result: '{dependencyResult.ResultType}'");
+
+                if (dependencyResult.ResultType != CacheResultType.CacheHit)
+                {
+                    logger.LogMessage($"Cache miss due to failed build result for dependency '{dependency.Id}'");
+                    _recordDependencyCacheMiss();
+                    return new NodeCacheResult(CacheResult.IndicateNonCacheHit(CacheResultType.CacheMiss), null);
+                }
+            }
+        }
+
+        return await _getCacheResultSingleAsync(nodeContext, materializeOutputs, logger, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Why

Recursive cache queries can memoize a hit without materializing its outputs. If MSBuild later directly queries that node out of graph order, the memoized result was returned without placing required outputs such as reference assemblies.

## What changed

- Separate recursive result memoization from an idempotent materialization handle, allowing a later direct query to place outputs exactly once without repeating built-in cache lookup or mutating `NodeContext.BuildResult` again.
- Coordinate concurrent and dependency queries, including forcing discovered dependency outputs before executing a parent cache miss.
- Preserve outer-build handling for multi-targeting inner builds, asynchronous materialization semantics, the default non-recursive path, and the existing public cache client API.
- Add deterministic regression coverage for out-of-order queries, concurrency, dependency misses, materialization idempotence, and outer/inner builds.

## Validation

- Focused regression tests: 6 passed on `net9.0`
- Common test suite: 143 passed on `net9.0`
- Common test suite: 143 passed on `net472`
- Full solution build: succeeded with 0 warnings and 0 errors

Fixes: #167