### PR TITLE
Ensure cache cleanup after async shutdown failures

### DIFF
--- a/src/Common.Tests/MSBuildCachePluginBaseTests.cs
+++ b/src/Common.Tests/MSBuildCachePluginBaseTests.cs
@@ -5,10 +5,16 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using BuildXL.Cache.ContentStore.Hashing;
 using DotNet.Globbing;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
+using Microsoft.Build.Experimental.ProjectCache;
+using Microsoft.MSBuildCache.Caching;
+using Microsoft.MSBuildCache.Fingerprinting;
 using Microsoft.MSBuildCache.Tests.Mocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -154,4 +160,155 @@ public sealed class MSBuildCachePluginBaseTests
             Array.Empty<string>(),
             null,
             new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+    [TestMethod]
+    [DoNotParallelize]
+#pragma warning disable CA2000 // Ownership is transferred to the plugin; the finally block disposes only if EndBuildAsync did not.
+    public async Task EndBuildAsyncDisposesCacheClientAndPreservesExceptionWhenAsynchronousPublishingFails()
+    {
+        FaultingCacheClient cacheClient = new("publishing");
+        TestPlugin plugin = new();
+        SetCacheClient(plugin, cacheClient);
+
+        try
+        {
+            AggregateException exception = await Assert.ThrowsExactlyAsync<AggregateException>(
+                () => plugin.EndBuildAsync(NullPluginLogger.Instance, CancellationToken.None));
+
+            Assert.AreSame(cacheClient.ShutdownFailure, exception);
+            Assert.IsTrue(cacheClient.DisposeCalled, "The cache client must be disposed after shutdown fails.");
+        }
+        finally
+        {
+            if (!cacheClient.DisposeCalled)
+            {
+                await plugin.DisposeAsync();
+            }
+        }
+    }
+#pragma warning restore CA2000
+
+    [TestMethod]
+    [DoNotParallelize]
+#pragma warning disable CA2000 // Ownership is transferred to the plugins; the finally block avoids releasing a shared lock twice.
+    public async Task EndBuildAsyncReleasesProcessAndDirectoryLocksWhenAsynchronousMaterializationFails()
+    {
+        string cacheRoot = Path.Combine(Path.GetTempPath(), "MSBuildCacheTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(cacheRoot);
+
+        PluginSettings settings = new()
+        {
+            RepoRoot = cacheRoot,
+            LocalCacheRootPath = cacheRoot,
+        };
+
+        FaultingCacheClient cacheClient = new("materialization");
+        TestPlugin firstPlugin = new();
+        TestPlugin secondPlugin = new();
+        bool firstPluginAcquiredLocks = false;
+        bool secondPluginAcquiredLocks = false;
+
+        try
+        {
+            firstPluginAcquiredLocks = TryAcquireLock(firstPlugin, settings);
+            Assert.IsTrue(firstPluginAcquiredLocks, "The first plugin must acquire both locks for the test to be valid.");
+            SetCacheClient(firstPlugin, cacheClient);
+
+            AggregateException exception = await Assert.ThrowsExactlyAsync<AggregateException>(
+                () => firstPlugin.EndBuildAsync(NullPluginLogger.Instance, CancellationToken.None));
+            Assert.AreSame(cacheClient.ShutdownFailure, exception);
+
+            secondPluginAcquiredLocks = TryAcquireLock(secondPlugin, settings);
+            Assert.IsTrue(
+                secondPluginAcquiredLocks,
+                "A subsequent plugin must be able to reacquire both the process-wide semaphore and cache directory lock.");
+        }
+#pragma warning restore CA2000
+        finally
+        {
+            if (firstPluginAcquiredLocks && !cacheClient.DisposeCalled)
+            {
+                await firstPlugin.DisposeAsync();
+            }
+
+            if (secondPluginAcquiredLocks)
+            {
+                await secondPlugin.DisposeAsync();
+            }
+
+            Directory.Delete(cacheRoot, recursive: true);
+        }
+    }
+
+    private static void SetCacheClient(TestPlugin plugin, ICacheClient cacheClient)
+    {
+        FieldInfo cacheClientField = typeof(MSBuildCachePluginBase<PluginSettings>).GetField(
+            "_cacheClient",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        cacheClientField.SetValue(plugin, cacheClient);
+    }
+
+    private static bool TryAcquireLock(TestPlugin plugin, PluginSettings settings)
+    {
+        MethodInfo tryAcquireLockMethod = typeof(MSBuildCachePluginBase<PluginSettings>).GetMethod(
+            "TryAcquireLock",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (bool)tryAcquireLockMethod.Invoke(plugin, [settings, NullPluginLogger.Instance])!;
+    }
+
+    private sealed class TestPlugin : MSBuildCachePluginBase
+    {
+        protected override HashType HashType => HashType.Murmur;
+
+        protected override Task<ICacheClient> CreateCacheClientAsync(PluginLoggerBase logger, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class FaultingCacheClient : ICacheClient
+    {
+        private readonly Task _backgroundOperation;
+
+        public FaultingCacheClient(string operationName)
+        {
+            IOException backgroundFailure = new($"Asynchronous {operationName} failed.");
+            _backgroundOperation = Task.FromException(backgroundFailure);
+            ShutdownFailure = new AggregateException(backgroundFailure);
+        }
+
+        public bool DisposeCalled { get; private set; }
+
+        public AggregateException ShutdownFailure { get; }
+
+        public Task<NodeBuildResult> AddNodeAsync(
+            NodeContext nodeContext,
+            PathSet? pathSet,
+            IReadOnlyCollection<string> outputPaths,
+            Func<IReadOnlyDictionary<string, ContentHash>, NodeBuildResult> nodeBuildResultBuilder,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<(PathSet?, NodeBuildResult?)> GetNodeAsync(
+            NodeContext nodeContext,
+            bool materializeOutputs,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public async Task ShutdownAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _backgroundOperation;
+            }
+            catch (IOException)
+            {
+                throw ShutdownFailure;
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCalled = true;
+            return default;
+        }
+    }
 }

--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -12,7 +12,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -145,58 +144,21 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
     {
         GC.SuppressFinalize(this);
 
-        List<Exception> exceptions = new();
-
-        ICacheClient? cacheClient = _cacheClient;
-        _cacheClient = null;
-        if (cacheClient != null)
+        if (_cacheClient != null)
         {
-            await CaptureExceptionAsync(cacheClient.DisposeAsync, exceptions);
+            await _cacheClient.DisposeAsync();
         }
 
-        IContentHasher? contentHasher = ContentHasher;
-        ContentHasher = null;
-        if (contentHasher != null)
+        ContentHasher?.Dispose();
+
+        if (_fileAccessRepository is IDisposable fileAccessRepositoryDisposable)
         {
-            CaptureException(contentHasher.Dispose, exceptions);
+            fileAccessRepositoryDisposable.Dispose();
         }
 
-        if (_fileAccessRepository != null)
-        {
-            try
-            {
-                _fileAccessRepository.Dispose();
-            }
-            catch (Exception ex)
-            {
-                exceptions.Add(ex);
-            }
-        }
-
-        _fileAccessRepository = null;
         _outputProducer.Clear();
-
-        if (_localCacheDirectoryLock != null)
-        {
-            try
-            {
-                _localCacheDirectoryLock.Dispose();
-            }
-            catch (Exception ex)
-            {
-                exceptions.Add(ex);
-            }
-        }
-
-        _localCacheDirectoryLock = null;
-        SemaphoreSlim? singlePluginInstanceMutex = _singlePluginInstanceMutex;
-        _singlePluginInstanceMutex = null;
-        if (singlePluginInstanceMutex != null)
-        {
-            CaptureException(() => singlePluginInstanceMutex.Release(), exceptions);
-        }
-
-        ThrowIfAny(exceptions);
+        _localCacheDirectoryLock?.Dispose();
+        _singlePluginInstanceMutex?.Release();
     }
 
     protected virtual string? GetBuildId()
@@ -395,18 +357,24 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
 
     private async Task EndBuildInnerAsync(PluginLoggerBase logger, CancellationToken cancellationToken)
     {
-        List<Exception> exceptions = new();
-
-        ICacheClient? cacheClient = _cacheClient;
-        if (cacheClient is not null)
+        try
         {
-            await CaptureExceptionAsync(() => new ValueTask(cacheClient.ShutdownAsync(cancellationToken)), exceptions);
+            if (_cacheClient is not null)
+            {
+                await _cacheClient.ShutdownAsync(cancellationToken);
+            }
         }
-
-        await CaptureExceptionAsync(DisposeAsync, exceptions);
-        _pluginLogger = null;
-
-        ThrowIfAny(exceptions);
+        finally
+        {
+            try
+            {
+                await DisposeAsync();
+            }
+            finally
+            {
+                _pluginLogger = null;
+            }
+        }
 
         LogCacheStats(logger);
     }
@@ -1409,43 +1377,6 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
         {
             logger.LogWarning($"{memberName} failed after {timer.ElapsedMilliseconds} ms: {e}");
             throw;
-        }
-    }
-
-    private static void CaptureException(Action action, List<Exception> exceptions)
-    {
-        try
-        {
-            action();
-        }
-        catch (Exception ex)
-        {
-            exceptions.Add(ex);
-        }
-    }
-
-    private static async ValueTask CaptureExceptionAsync(Func<ValueTask> action, List<Exception> exceptions)
-    {
-        try
-        {
-            await action();
-        }
-        catch (Exception ex)
-        {
-            exceptions.Add(ex);
-        }
-    }
-
-    private static void ThrowIfAny(List<Exception> exceptions)
-    {
-        if (exceptions.Count == 1)
-        {
-            ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
-        }
-
-        if (exceptions.Count > 1)
-        {
-            throw new AggregateException(exceptions);
         }
     }
 

--- a/src/Common/MSBuildCachePluginBase.cs
+++ b/src/Common/MSBuildCachePluginBase.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -144,21 +145,58 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
     {
         GC.SuppressFinalize(this);
 
-        if (_cacheClient != null)
+        List<Exception> exceptions = new();
+
+        ICacheClient? cacheClient = _cacheClient;
+        _cacheClient = null;
+        if (cacheClient != null)
         {
-            await _cacheClient.DisposeAsync();
+            await CaptureExceptionAsync(cacheClient.DisposeAsync, exceptions);
         }
 
-        ContentHasher?.Dispose();
-
-        if (_fileAccessRepository is IDisposable fileAccessRepositoryDisposable)
+        IContentHasher? contentHasher = ContentHasher;
+        ContentHasher = null;
+        if (contentHasher != null)
         {
-            fileAccessRepositoryDisposable.Dispose();
+            CaptureException(contentHasher.Dispose, exceptions);
         }
 
+        if (_fileAccessRepository != null)
+        {
+            try
+            {
+                _fileAccessRepository.Dispose();
+            }
+            catch (Exception ex)
+            {
+                exceptions.Add(ex);
+            }
+        }
+
+        _fileAccessRepository = null;
         _outputProducer.Clear();
-        _localCacheDirectoryLock?.Dispose();
-        _singlePluginInstanceMutex?.Release();
+
+        if (_localCacheDirectoryLock != null)
+        {
+            try
+            {
+                _localCacheDirectoryLock.Dispose();
+            }
+            catch (Exception ex)
+            {
+                exceptions.Add(ex);
+            }
+        }
+
+        _localCacheDirectoryLock = null;
+        SemaphoreSlim? singlePluginInstanceMutex = _singlePluginInstanceMutex;
+        _singlePluginInstanceMutex = null;
+        if (singlePluginInstanceMutex != null)
+        {
+            CaptureException(() => singlePluginInstanceMutex.Release(), exceptions);
+        }
+
+        ThrowIfAny(exceptions);
     }
 
     protected virtual string? GetBuildId()
@@ -357,16 +395,20 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
 
     private async Task EndBuildInnerAsync(PluginLoggerBase logger, CancellationToken cancellationToken)
     {
-        if (_cacheClient is not null)
+        List<Exception> exceptions = new();
+
+        ICacheClient? cacheClient = _cacheClient;
+        if (cacheClient is not null)
         {
-            await _cacheClient.ShutdownAsync(cancellationToken);
+            await CaptureExceptionAsync(() => new ValueTask(cacheClient.ShutdownAsync(cancellationToken)), exceptions);
         }
 
-        await DisposeAsync();
+        await CaptureExceptionAsync(DisposeAsync, exceptions);
+        _pluginLogger = null;
+
+        ThrowIfAny(exceptions);
 
         LogCacheStats(logger);
-
-        _pluginLogger = null;
     }
 
     public override Task<CacheResult> GetCacheResultAsync(BuildRequestData buildRequest, PluginLoggerBase logger, CancellationToken cancellationToken)
@@ -1367,6 +1409,43 @@ public abstract class MSBuildCachePluginBase<TPluginSettings> : ProjectCachePlug
         {
             logger.LogWarning($"{memberName} failed after {timer.ElapsedMilliseconds} ms: {e}");
             throw;
+        }
+    }
+
+    private static void CaptureException(Action action, List<Exception> exceptions)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex)
+        {
+            exceptions.Add(ex);
+        }
+    }
+
+    private static async ValueTask CaptureExceptionAsync(Func<ValueTask> action, List<Exception> exceptions)
+    {
+        try
+        {
+            await action();
+        }
+        catch (Exception ex)
+        {
+            exceptions.Add(ex);
+        }
+    }
+
+    private static void ThrowIfAny(List<Exception> exceptions)
+    {
+        if (exceptions.Count == 1)
+        {
+            ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+        }
+
+        if (exceptions.Count > 1)
+        {
+            throw new AggregateException(exceptions);
         }
     }
 


### PR DESCRIPTION
A failed asynchronous publish or materialization currently prevents plugin teardown, leaving cache resources and process-wide locks held for later builds in the same MSBuild node.

This change records shutdown failures, always runs disposal, continues cleanup across individual disposal errors, and rethrows the original shutdown exception when it is the only failure. Focused regression tests cover cache-client disposal, exception identity, and reacquiring both directory and process-wide locks.

**Validation**
- Focused regression tests on `net9.0` and `net472`: 4 passed
- Full Common test suite on `net9.0`: 139 passed
- Full solution build: succeeded with 0 warnings and 0 errors

Fixes: #163