### PR TITLE
Bound Azure Pipelines selector history

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ It is expected that this plugin is used within an Azure Pipeline. The `SYSTEM_AC
 
 `$(System.AccessToken)` by default does not have the scope relevant to Pipeline Caching. The scope can be enabled by setting the `EnablePipelineCache` pipeline variable. Additionally, the scope will get automatically added if the [Cache task](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#cache-task-how-it-works) is used somewhere in the pipeline.
 
+These settings are available in addition to the [Common Settings](#common-settings):
+
+| MSBuild Property Name | Setting Type | Default value | Description |
+| ------------- | ------------ | ------------- | ----------- |
+| `$(MSBuildCacheMaxSelectorsPerWeakFingerprint)` | `int` | 10 | The maximum number of recently published selectors retained for each weak fingerprint. Lower values reduce selector-manifest publishing work; higher values preserve more historical cache candidates. |
+
 ### Microsoft.MSBuildCache.Local
 [![NuGet Version](https://img.shields.io/nuget/v/Microsoft.MSBuildCache.Local.svg)](https://www.nuget.org/packages/Microsoft.MSBuildCache.Local)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Microsoft.MSBuildCache.Local.svg)](https://www.nuget.org/packages/Microsoft.MSBuildCache.Local)

--- a/src/AzurePipelines/MSBuildCacheAzurePipelinesPlugin.cs
+++ b/src/AzurePipelines/MSBuildCacheAzurePipelinesPlugin.cs
@@ -33,6 +33,12 @@ public sealed class MSBuildCacheAzurePipelinesPlugin : MSBuildCachePluginBase
             throw new InvalidOperationException();
         }
 
+        if (Settings.MaxSelectorsPerWeakFingerprint <= 0)
+        {
+            throw new InvalidOperationException(
+                $"The {nameof(PluginSettings.MaxSelectorsPerWeakFingerprint)} setting must be positive, but was {Settings.MaxSelectorsPerWeakFingerprint}.");
+        }
+
         logger.LogMessage($"Using Azure DevOps with session '{AzDOHelpers.SessionGuid}'.", MessageImportance.Normal);
 
         FileLog fileLog = new(Path.Combine(Settings.LogDirectory, "CacheClient.log"));
@@ -63,7 +69,8 @@ public sealed class MSBuildCacheAzurePipelinesPlugin : MSBuildCachePluginBase
             Settings.AsyncCachePublishing,
             Settings.AsyncCacheMaterialization,
             Settings.SkipUnchangedOutputFiles,
-            Settings.TouchOutputFiles);
+            Settings.TouchOutputFiles,
+            Settings.MaxSelectorsPerWeakFingerprint);
     }
 
     private static async Task<ICacheSession> StartCacheSessionAsync(Context context, LocalCache cache, string name)

--- a/src/AzurePipelines/PipelineCachingCacheClient.cs
+++ b/src/AzurePipelines/PipelineCachingCacheClient.cs
@@ -53,9 +53,8 @@ namespace Microsoft.MSBuildCache.AzurePipelines;
 /// 
 /// For first phase we'll have the Manifest:
 ///  1. itself include any PathSet content (not really working yet)
-///  2. include all selectors as custom metadata
-/// Because this is 1->1, we'll basically accumulate selectors here.
-/// We'll probably need to add some kind of LRU so it doesn't grow unbounded.
+///  2. include a bounded window of recently published selectors as custom metadata
+/// Because this is 1->1, each publication carries the most recent distinct selectors forward.
 ///  
 /// For second phase we'll have the Manifest
 ///  1. itself include references to the output content 
@@ -71,9 +70,11 @@ internal sealed class PipelineCachingCacheClient : CacheClient
 
     private const string NodeBuildResultRelativePath = $"{InternalMetadataPathPrefix}/NodeBuildResult";
     private const string PathSetRelativePathBase = $"{InternalMetadataPathPrefix}/PathSets";
-    private static string PathSetRelativePath(Selector s) => $"{PathSetRelativePathBase}/{s.ContentHash}";
+    private static string PathSetRelativePath(ContentHash pathSetHash) => $"{PathSetRelativePathBase}/{pathSetHash}";
     private const string SelectorsRelativePathBase = $"{InternalMetadataPathPrefix}/Selectors";
     internal static string SelectorRelativePath(Selector s) => $"{SelectorsRelativePathBase}/{s.ContentHash}/{s.Output.ToHexString()}";
+    private const string SelectorOrderRelativePathBase = $"{InternalMetadataPathPrefix}/SelectorOrder";
+    private static string SelectorOrderRelativePath(Selector s, int index) => SelectorManifestHistory.CreateOrderPath(SelectorOrderRelativePathBase, s, index);
 
     // Prefer a temp directory on the same drive as the repo root so that hard links work.
     private static readonly string TempFolder = Environment.GetEnvironmentVariable("AGENT_TEMPDIRECTORY") ?? Path.GetTempPath();
@@ -89,6 +90,7 @@ internal sealed class PipelineCachingCacheClient : CacheClient
     private readonly DedupStoreHttpClient _dedupHttpClient;
     private readonly DedupStoreClientWithDataport _dedupClient;
     private readonly DedupManifestArtifactClient _manifestClient;
+    private readonly int _maxSelectorsPerWeakFingerprint;
     private readonly Task _startupTask;
 
     public PipelineCachingCacheClient(
@@ -107,10 +109,17 @@ internal sealed class PipelineCachingCacheClient : CacheClient
         bool enableAsyncPublishing,
         bool enableAsyncMaterialization,
         bool skipUnchangedOutputFiles,
-        bool touchOutputFiles)
+        bool touchOutputFiles,
+        int maxSelectorsPerWeakFingerprint)
         : base(rootContext, fingerprintFactory, hasher, repoRoot, nugetPackageRoot, getFileRealizationMode, localCache, localCAS, maxConcurrentCacheContentOperations, enableAsyncPublishing, enableAsyncMaterialization, skipUnchangedOutputFiles, touchOutputFiles)
     {
+        if (maxSelectorsPerWeakFingerprint <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxSelectorsPerWeakFingerprint), maxSelectorsPerWeakFingerprint, "The selector retention limit must be positive.");
+        }
+
         _remoteCacheIsReadOnly = remoteCacheIsReadOnly;
+        _maxSelectorsPerWeakFingerprint = maxSelectorsPerWeakFingerprint;
         _universe = $"pccc-{(int)hasher.Info.HashType}-{InternalSeed}-" + (string.IsNullOrEmpty(universe) ? "DEFAULT" : universe);
 
         _azureDevopsTracer = new CallbackAppTraceSource(
@@ -322,45 +331,47 @@ internal sealed class PipelineCachingCacheClient : CacheClient
 
             string key = ComputeSelectorsKey(fingerprint.WeakFingerprint, forWrite: true);
 
-            var selectors = await GetSelectors(context, fingerprint.WeakFingerprint, cancellationToken).ToHashSetAsync(cancellationToken);
+            List<Selector> previousSelectors = await GetSelectors(context, fingerprint.WeakFingerprint, cancellationToken).ToListAsync(cancellationToken);
+            SelectorManifestPlan selectorPlan = SelectorRetentionPolicy.CreatePlan(
+                previousSelectors,
+                fingerprint.Selector,
+                EmptySelector.ContentHash,
+                pathSetBytes?.hash,
+                _maxSelectorsPerWeakFingerprint);
 
-            selectors.Add(fingerprint.Selector);
+            Dictionary<string, FileInfo> extras = new((selectorPlan.Selectors.Count * 2) + selectorPlan.PathSets.Count);
 
-            // TODO: limit the number of selectors we store.
-
-            Dictionary<string, FileInfo> extras = new(selectors.Count);
-
-            foreach (Selector selector in selectors)
+            for (int selectorIndex = 0; selectorIndex < selectorPlan.Selectors.Count; selectorIndex++)
             {
+                Selector selector = selectorPlan.Selectors[selectorIndex];
+
                 // the selector is just a fake file
                 extras.Add(SelectorRelativePath(selector), emptyFileInfo);
+                extras.Add(SelectorOrderRelativePath(selector, selectorIndex), emptyFileInfo);
+            }
 
-                // Multiple selectors may have the same pathset hash but different outputs (eg, if a non-predicted output changed),
-                // so only add it once.
-                string pathSetRelativePath = PathSetRelativePath(selector);
-                if (selector.ContentHash != EmptySelector.ContentHash
-                    && !extras.ContainsKey(pathSetRelativePath))
-                {
+            foreach (SelectorPathSet pathSet in selectorPlan.PathSets)
+            {
 #if NET9_0
 #pragma warning disable IDE0079
 #pragma warning disable CA2000
 #endif
-                    var pathSetTempFile = new TempFile(FileSystem.Instance, TempFolder);
+                var pathSetTempFile = new TempFile(FileSystem.Instance, TempFolder);
 #if NET9_0
 #pragma warning restore CA2000
 #pragma warning restore IDE0079
 #endif
-                    var bytes = selector.ContentHash == pathSetBytes?.hash
-                        ? pathSetBytes.Value.bytes
-                        : await GetBytes(context, selector.ContentHash.ToBlobIdentifier().ToDedupIdentifier(), cancellationToken);
+                pathSetTempFiles.Add(pathSetTempFile);
+
+                byte[] bytes = pathSet.RequiresDownload
+                    ? await GetBytes(context, pathSet.ContentHash.ToBlobIdentifier().ToDedupIdentifier(), cancellationToken)
+                    : pathSetBytes!.Value.bytes;
 #if NETFRAMEWORK
-                    File.WriteAllBytes(pathSetTempFile.Path, bytes);
+                File.WriteAllBytes(pathSetTempFile.Path, bytes);
 #else
-                    await File.WriteAllBytesAsync(pathSetTempFile.Path, bytes, cancellationToken);
+                await File.WriteAllBytesAsync(pathSetTempFile.Path, bytes, cancellationToken);
 #endif
-                    extras.Add(pathSetRelativePath, new FileInfo(pathSetTempFile.Path));
-                    pathSetTempFiles.Add(pathSetTempFile);
-                }
+                extras.Add(PathSetRelativePath(pathSet.ContentHash), new FileInfo(pathSetTempFile.Path));
             }
 
             var result = await WithHttpRetries(
@@ -603,10 +614,13 @@ internal sealed class PipelineCachingCacheClient : CacheClient
 
         using var manifestStream = new MemoryStream(await GetBytes(context, result.ManifestId, cancellationToken));
         Manifest manifest = JsonSerializer.Deserialize<Manifest>(manifestStream)!;
-        foreach (ManifestItem selectorItem in manifest.Items.Where(i => i.Path.StartsWith(SelectorsRelativePathBase, StringComparison.Ordinal)))
+        IReadOnlyList<Selector> selectors = SelectorManifestHistory.ReadSelectors(
+            manifest.Items.Select(item => item.Path),
+            SelectorsRelativePathBase,
+            SelectorOrderRelativePathBase);
+        foreach (Selector selector in selectors)
         {
-            string[] tokens = selectorItem.Path.Substring(SelectorsRelativePathBase.Length + 1).Split('/');
-            yield return new Selector(new ContentHash(tokens[0]), HexUtilities.HexToBytes(tokens[1]));
+            yield return selector;
         }
     }
 

--- a/src/AzurePipelines/build/Microsoft.MSBuildCache.AzurePipelines.targets
+++ b/src/AzurePipelines/build/Microsoft.MSBuildCache.AzurePipelines.targets
@@ -1,3 +1,13 @@
 <Project>
+  <PropertyGroup Condition="'$(MSBuildCacheEnabled)' != 'false'">
+    <MSBuildCacheGlobalPropertiesToIgnore>$(MSBuildCacheGlobalPropertiesToIgnore);MSBuildCacheMaxSelectorsPerWeakFingerprint</MSBuildCacheGlobalPropertiesToIgnore>
+  </PropertyGroup>
+
   <Import Project="Microsoft.MSBuildCache.Common.targets" />
+
+  <ItemGroup Condition="'$(MSBuildCacheEnabled)' != 'false'">
+    <ProjectCachePlugin Update="$(MSBuildCacheAssembly)">
+      <MaxSelectorsPerWeakFingerprint>$(MSBuildCacheMaxSelectorsPerWeakFingerprint)</MaxSelectorsPerWeakFingerprint>
+    </ProjectCachePlugin>
+  </ItemGroup>
 </Project>

--- a/src/Common.Tests/Caching/SelectorManifestHistoryTests.cs
+++ b/src/Common.Tests/Caching/SelectorManifestHistoryTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using BuildXL.Cache.ContentStore.Hashing;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+using Microsoft.MSBuildCache.Caching;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.MSBuildCache.Tests.Caching;
+
+[TestClass]
+public sealed class SelectorManifestHistoryTests
+{
+    private const string LegacyBasePath = "/metadata/Selectors";
+    private const string OrderBasePath = "/metadata/SelectorOrder";
+
+    [TestMethod]
+    public void ExplicitOrderSurvivesManifestPathSorting()
+    {
+        Selector newest = CreateSelector(1);
+        Selector middle = CreateSelector(2);
+        Selector oldest = CreateSelector(3);
+        Selector[] expected = [newest, middle, oldest];
+
+        var manifestPaths = new List<string>();
+        for (int index = 0; index < expected.Length; index++)
+        {
+            Selector selector = expected[index];
+            manifestPaths.Add(CreateLegacyPath(selector));
+            manifestPaths.Add(SelectorManifestHistory.CreateOrderPath(OrderBasePath, selector, index));
+        }
+
+        manifestPaths.Sort(System.StringComparer.Ordinal);
+
+        CollectionAssert.AreEqual(
+            expected,
+            SelectorManifestHistory.ReadSelectors(manifestPaths, LegacyBasePath, OrderBasePath).ToArray());
+    }
+
+    [TestMethod]
+    public void LegacyManifestRemainsReadable()
+    {
+        Selector firstByManifestOrder = CreateSelector(1);
+        Selector secondByManifestOrder = CreateSelector(2);
+        string[] manifestPaths =
+        [
+            CreateLegacyPath(firstByManifestOrder),
+            CreateLegacyPath(secondByManifestOrder),
+        ];
+
+        CollectionAssert.AreEqual(
+            new[] { firstByManifestOrder, secondByManifestOrder },
+            SelectorManifestHistory.ReadSelectors(manifestPaths, LegacyBasePath, OrderBasePath).ToArray());
+    }
+
+    private static Selector CreateSelector(int output)
+        => new(ContentHash.Random(), System.BitConverter.GetBytes(output));
+
+    private static string CreateLegacyPath(Selector selector)
+        => $"{LegacyBasePath}/{selector.ContentHash}/{HexUtilities.BytesToHex(selector.Output)}";
+}

--- a/src/Common.Tests/Caching/SelectorRetentionPolicyTests.cs
+++ b/src/Common.Tests/Caching/SelectorRetentionPolicyTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BuildXL.Cache.ContentStore.Hashing;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+using Microsoft.MSBuildCache.Caching;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.MSBuildCache.Tests.Caching;
+
+[TestClass]
+public sealed class SelectorRetentionPolicyTests
+{
+    [TestMethod]
+    public void SelectorChurnKeepsTheMostRecentWindow()
+    {
+        const int retentionLimit = 4;
+        var publishedSelectors = new List<Selector>();
+        var selectorsByAge = new List<Selector>();
+        ContentHash emptySelectorHash = ContentHash.Random();
+
+        for (int i = 0; i < 20; i++)
+        {
+            Selector currentSelector = CreateSelector(ContentHash.Random(), i);
+            selectorsByAge.Insert(0, currentSelector);
+
+            SelectorManifestPlan plan = SelectorRetentionPolicy.CreatePlan(
+                publishedSelectors,
+                currentSelector,
+                emptySelectorHash,
+                currentSelector.ContentHash,
+                retentionLimit);
+
+            publishedSelectors = plan.Selectors.ToList();
+        }
+
+        CollectionAssert.AreEqual(selectorsByAge.Take(retentionLimit).ToList(), publishedSelectors);
+    }
+
+    [TestMethod]
+    public void DuplicateSelectorsAndPathSetsArePublishedOnce()
+    {
+        ContentHash emptySelectorHash = ContentHash.Random();
+        ContentHash sharedPathSetHash = ContentHash.Random();
+        Selector currentSelector = CreateSelector(sharedPathSetHash, 1);
+        Selector samePathSetDifferentOutput = CreateSelector(sharedPathSetHash, 2);
+
+        SelectorManifestPlan plan = SelectorRetentionPolicy.CreatePlan(
+            new[] { currentSelector, samePathSetDifferentOutput, currentSelector },
+            currentSelector,
+            emptySelectorHash,
+            sharedPathSetHash,
+            maxSelectors: 10);
+
+        CollectionAssert.AreEqual(
+            new[] { currentSelector, samePathSetDifferentOutput },
+            plan.Selectors.ToList());
+        Assert.HasCount(1, plan.PathSets);
+        Assert.IsFalse(plan.PathSets[0].RequiresDownload);
+    }
+
+    [TestMethod]
+    public void OldestSelectorIsEvictedAtTheLimit()
+    {
+        ContentHash emptySelectorHash = ContentHash.Random();
+        Selector currentSelector = CreateSelector(ContentHash.Random(), 3);
+        Selector recentSelector = CreateSelector(ContentHash.Random(), 2);
+        Selector oldestSelector = CreateSelector(ContentHash.Random(), 1);
+
+        SelectorManifestPlan plan = SelectorRetentionPolicy.CreatePlan(
+            new[] { recentSelector, oldestSelector },
+            currentSelector,
+            emptySelectorHash,
+            currentSelector.ContentHash,
+            maxSelectors: 2);
+
+        CollectionAssert.AreEqual(new[] { currentSelector, recentSelector }, plan.Selectors.ToList());
+    }
+
+    [TestMethod]
+    public void HistoricalPathSetDownloadsAreBounded()
+    {
+        const int retentionLimit = 8;
+        ContentHash emptySelectorHash = ContentHash.Random();
+        Selector currentSelector = CreateSelector(ContentHash.Random(), 100);
+        var historicalSelectors = Enumerable.Range(0, 100)
+            .Select(i => CreateSelector(ContentHash.Random(), i))
+            .ToList();
+
+        SelectorManifestPlan plan = SelectorRetentionPolicy.CreatePlan(
+            historicalSelectors,
+            currentSelector,
+            emptySelectorHash,
+            currentSelector.ContentHash,
+            retentionLimit);
+
+        Assert.HasCount(retentionLimit, plan.Selectors);
+        Assert.HasCount(retentionLimit, plan.PathSets);
+        Assert.AreEqual(retentionLimit - 1, plan.PathSets.Count(pathSet => pathSet.RequiresDownload));
+    }
+
+    [TestMethod]
+    public void NonPositiveRetentionLimitIsRejected()
+    {
+        Selector selector = CreateSelector(ContentHash.Random(), 1);
+
+        _ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => SelectorRetentionPolicy.CreatePlan(
+            Array.Empty<Selector>(),
+            selector,
+            ContentHash.Random(),
+            selector.ContentHash,
+            maxSelectors: 0));
+    }
+
+    private static Selector CreateSelector(ContentHash pathSetHash, int output)
+        => new(pathSetHash, BitConverter.GetBytes(output));
+}

--- a/src/Common.Tests/HexUtilitiesTests.cs
+++ b/src/Common.Tests/HexUtilitiesTests.cs
@@ -11,6 +11,12 @@ namespace Microsoft.MSBuildCache.Tests;
 public class HexUtilitiesTests
 {
     [TestMethod]
+    [DataRow(new byte[] { 0x01, 0x23, 0xAB, 0xCD, 0xEF }, "0123ABCDEF")]
+    [DataRow(new byte[0], "")]
+    public void BytesToHex(byte[] bytes, string expected)
+        => Assert.AreEqual(expected, HexUtilities.BytesToHex(bytes));
+
+    [TestMethod]
     [DataRow("0123456789ABCDEFabcdef", new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0xAB, 0xCD, 0xEF, })]
     [DataRow("", null)]
     [DataRow(null, null)]

--- a/src/Common.Tests/PluginSettingsTests.cs
+++ b/src/Common.Tests/PluginSettingsTests.cs
@@ -81,6 +81,13 @@ public sealed class PluginSettingsTests
             new[] { 123, 456, 789 });
 
     [TestMethod]
+    public void MaxSelectorsPerWeakFingerprintSetting()
+        => TestBasicSetting(
+            nameof(PluginSettings.MaxSelectorsPerWeakFingerprint),
+            pluginSettings => pluginSettings.MaxSelectorsPerWeakFingerprint,
+            new[] { 1, 10, 100 });
+
+    [TestMethod]
     public void LocalCacheRootPathSetting()
         => TestBasicSetting(
             nameof(PluginSettings.LocalCacheRootPath),

--- a/src/Common/Caching/SelectorManifestHistory.cs
+++ b/src/Common/Caching/SelectorManifestHistory.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BuildXL.Cache.ContentStore.Hashing;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+
+namespace Microsoft.MSBuildCache.Caching;
+
+internal static class SelectorManifestHistory
+{
+    public static string CreateOrderPath(string basePath, Selector selector, int index)
+        => $"{basePath}/{index:D8}/{selector.ContentHash}/{HexUtilities.BytesToHex(selector.Output)}";
+
+    public static IReadOnlyList<Selector> ReadSelectors(
+        IEnumerable<string> manifestPaths,
+        string legacyBasePath,
+        string orderBasePath)
+    {
+        List<string> paths = manifestPaths.ToList();
+        string orderPrefix = orderBasePath + "/";
+        List<Selector> orderedSelectors = paths
+            .Where(path => path.StartsWith(orderPrefix, StringComparison.Ordinal))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .Select(path => ParseSelector(path, orderPrefix, contentHashIndex: 1))
+            .ToList();
+
+        if (orderedSelectors.Count > 0)
+        {
+            return orderedSelectors;
+        }
+
+        string legacyPrefix = legacyBasePath + "/";
+        return paths
+            .Where(path => path.StartsWith(legacyPrefix, StringComparison.Ordinal))
+            .Select(path => ParseSelector(path, legacyPrefix, contentHashIndex: 0))
+            .ToList();
+    }
+
+    private static Selector ParseSelector(string path, string prefix, int contentHashIndex)
+    {
+        string[] tokens = path.Substring(prefix.Length).Split('/');
+        return new Selector(
+            new ContentHash(tokens[contentHashIndex]),
+            HexUtilities.HexToBytes(tokens[contentHashIndex + 1]));
+    }
+}

--- a/src/Common/Caching/SelectorRetentionPolicy.cs
+++ b/src/Common/Caching/SelectorRetentionPolicy.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using BuildXL.Cache.ContentStore.Hashing;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+
+namespace Microsoft.MSBuildCache.Caching;
+
+internal readonly record struct SelectorPathSet(ContentHash ContentHash, bool RequiresDownload);
+
+internal sealed class SelectorManifestPlan
+{
+    public SelectorManifestPlan(IReadOnlyList<Selector> selectors, IReadOnlyList<SelectorPathSet> pathSets)
+    {
+        Selectors = selectors;
+        PathSets = pathSets;
+    }
+
+    public IReadOnlyList<Selector> Selectors { get; }
+
+    public IReadOnlyList<SelectorPathSet> PathSets { get; }
+}
+
+internal static class SelectorRetentionPolicy
+{
+    public static SelectorManifestPlan CreatePlan(
+        IEnumerable<Selector> previousSelectors,
+        Selector currentSelector,
+        ContentHash emptySelectorContentHash,
+        ContentHash? locallyAvailablePathSetHash,
+        int maxSelectors)
+    {
+        if (maxSelectors <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxSelectors), maxSelectors, "The selector retention limit must be positive.");
+        }
+
+        var selectors = new List<Selector>(maxSelectors);
+        var seenSelectors = new HashSet<Selector>();
+
+        AddSelector(currentSelector);
+        foreach (Selector selector in previousSelectors)
+        {
+            if (selectors.Count == maxSelectors)
+            {
+                break;
+            }
+
+            AddSelector(selector);
+        }
+
+        var pathSets = new List<SelectorPathSet>(selectors.Count);
+        var seenPathSets = new HashSet<ContentHash>();
+        foreach (Selector selector in selectors)
+        {
+            ContentHash pathSetHash = selector.ContentHash;
+            if (pathSetHash != emptySelectorContentHash && seenPathSets.Add(pathSetHash))
+            {
+                pathSets.Add(new SelectorPathSet(
+                    pathSetHash,
+                    RequiresDownload: pathSetHash != locallyAvailablePathSetHash));
+            }
+        }
+
+        return new SelectorManifestPlan(selectors, pathSets);
+
+        void AddSelector(Selector selector)
+        {
+            if (seenSelectors.Add(selector))
+            {
+                selectors.Add(selector);
+            }
+        }
+    }
+}

--- a/src/Common/HexUtilities.cs
+++ b/src/Common/HexUtilities.cs
@@ -7,6 +7,8 @@ namespace Microsoft.MSBuildCache;
 
 public static class HexUtilities
 {
+    private const string HexCharacters = "0123456789ABCDEF";
+
     private static readonly ushort[] HexToNybble =
     {
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9,  // Character codes 0-9.
@@ -22,6 +24,19 @@ public static class HexUtilities
         => hex == null
             ? Array.Empty<byte>()
             : HexToBytes(hex.AsSpan());
+
+    internal static string BytesToHex(ReadOnlySpan<byte> bytes)
+    {
+        var result = new char[bytes.Length * 2];
+        for (int byteIndex = 0; byteIndex < bytes.Length; byteIndex++)
+        {
+            byte value = bytes[byteIndex];
+            result[byteIndex * 2] = HexCharacters[value >> 4];
+            result[(byteIndex * 2) + 1] = HexCharacters[value & 0x0F];
+        }
+
+        return new string(result);
+    }
 
     /// <summary>
     /// Parses hexadecimal strings the form '1234abcd' or '0x9876fedb' into

--- a/src/Common/Microsoft.MSBuildCache.Common.csproj
+++ b/src/Common/Microsoft.MSBuildCache.Common.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.MSBuildCache.Common.Tests" />
+    <InternalsVisibleTo Include="Microsoft.MSBuildCache.AzurePipelines" />
   </ItemGroup>
   <!-- Signing -->
   <ItemGroup>

--- a/src/Common/PluginSettings.cs
+++ b/src/Common/PluginSettings.cs
@@ -69,6 +69,11 @@ public class PluginSettings
     public int MaxConcurrentCacheContentOperations { get; init; } = 64;
 
     /// <summary>
+    /// Gets the maximum number of recently published selectors retained for each weak fingerprint by cache implementations that store selector history.
+    /// </summary>
+    public int MaxSelectorsPerWeakFingerprint { get; init; } = 10;
+
+    /// <summary>
     /// Base directory to use for the local cache. If null, the default value is the "MSBuildCache" folder in the root of the drive the repo root is on.
     /// </summary>
     public string LocalCacheRootPath


### PR DESCRIPTION
Azure Pipelines selector manifests currently carry every selector observed for a weak fingerprint, so selector churn makes each publish perform progressively more pathset downloads and remote work.

## Changes

- Retain a configurable MRU window of selectors per weak fingerprint, defaulting to 10.
- Promote the current selector, deduplicate selectors and shared pathsets, evict the oldest entries, and download only retained pathsets that are not locally available.
- Persist explicit selector order metadata so MRU order survives manifest path sorting, while continuing to publish and read legacy selector paths for compatibility with older clients.
- Wire `MSBuildCacheMaxSelectorsPerWeakFingerprint` through the Azure Pipelines targets and document the setting.

## Validation

- Azure Pipelines Release build passed for `net472` and `net9.0`.
- 188 focused test executions passed across both frameworks, covering churn, deduplication, eviction, bounded remote work, manifest ordering, legacy compatibility, setting parsing, and hex encoding.

Fixes: #164