### PR TITLE
Fix concurrent Pipeline Cache publication correctness

### DIFF
--- a/MSBuildCache.sln
+++ b/MSBuildCache.sln
@@ -34,6 +34,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.MSBuildCache.Loca
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.MSBuildCache.Repack.Tests", "src\Repack.Tests\Microsoft.MSBuildCache.Repack.Tests.csproj", "{3BCB6452-B087-4A03-8418-C79F2715DDE7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.MSBuildCache.AzurePipelines.Tests", "src\AzurePipelines.Tests\Microsoft.MSBuildCache.AzurePipelines.Tests.csproj", "{61A86AEA-F043-4CC4-B60B-A040C5C36194}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -68,6 +70,10 @@ Global
 		{3BCB6452-B087-4A03-8418-C79F2715DDE7}.Debug|x64.Build.0 = Debug|x64
 		{3BCB6452-B087-4A03-8418-C79F2715DDE7}.Release|x64.ActiveCfg = Release|x64
 		{3BCB6452-B087-4A03-8418-C79F2715DDE7}.Release|x64.Build.0 = Release|x64
+		{61A86AEA-F043-4CC4-B60B-A040C5C36194}.Debug|x64.ActiveCfg = Debug|x64
+		{61A86AEA-F043-4CC4-B60B-A040C5C36194}.Debug|x64.Build.0 = Debug|x64
+		{61A86AEA-F043-4CC4-B60B-A040C5C36194}.Release|x64.ActiveCfg = Release|x64
+		{61A86AEA-F043-4CC4-B60B-A040C5C36194}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -80,6 +86,7 @@ Global
 		{97357681-C75E-445D-8547-46F312D01CED} = {EFFB5949-347C-4F28-8964-571D5C6B6209}
 		{F6586428-E047-42C8-B0AC-048DF6DFAF18} = {EFFB5949-347C-4F28-8964-571D5C6B6209}
 		{3BCB6452-B087-4A03-8418-C79F2715DDE7} = {EFFB5949-347C-4F28-8964-571D5C6B6209}
+		{61A86AEA-F043-4CC4-B60B-A040C5C36194} = {EFFB5949-347C-4F28-8964-571D5C6B6209}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F1CDA78F-A666-431B-BF44-56DA7DF193BA}

--- a/src/AzurePipelines.Tests/Microsoft.MSBuildCache.AzurePipelines.Tests.csproj
+++ b/src/AzurePipelines.Tests/Microsoft.MSBuildCache.AzurePipelines.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="MSTest.Sdk">
+  <PropertyGroup>
+    <!-- Only supports x64 due to the RocksDB dependency -->
+    <Platform>x64</Platform>
+    <Platforms>$(Platform)</Platforms>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>Microsoft.MSBuildCache.AzurePipelines.Tests</RootNamespace>
+    <!-- MSTest requires public test classes even though the test host is an application. -->
+    <NoWarn>$(NoWarn);CA1515</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AzurePipelines\Microsoft.MSBuildCache.AzurePipelines.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/AzurePipelines.Tests/SelectorPublicationTests.cs
+++ b/src/AzurePipelines.Tests/SelectorPublicationTests.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildXL.Cache.ContentStore.Hashing;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.MSBuildCache.AzurePipelines.Tests;
+
+[TestClass]
+public class SelectorPublicationTests
+{
+    [TestMethod]
+    public async Task ConcurrentPublicationsMergeTheConflictWinner()
+    {
+        Selector existingSelector = CreateSelector(1);
+        Selector firstSelector = CreateSelector(2);
+        Selector secondSelector = CreateSelector(3);
+        Fingerprint weakFingerprint = new("01");
+        const string Universe = "universe";
+        string latestKey = PipelineCachingCacheClient.ComputeSelectorsReadKey(Universe, weakFingerprint);
+        PublicationState initial = new("initial", new[] { existingSelector });
+        ConcurrentDictionary<string, PublicationState> entries = new();
+        ConcurrentQueue<string> conflictQueries = new();
+        PublicationState? firstWinner = null;
+        PublicationState? finalWinner = null;
+        string? finalWriteKey = null;
+        int initialAttempts = 0;
+        TaskCompletionSource<bool> bothInitialAttemptsStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<bool> firstWinnerReady = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<PublicationState?> QueryAsync(string key, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (key == latestKey)
+            {
+                return Task.FromResult<PublicationState?>(initial);
+            }
+
+            entries.TryGetValue(key, out PublicationState? entry);
+            return Task.FromResult(entry);
+        }
+
+        Task<PublicationState> GetConflictWinnerAsync(string key, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            conflictQueries.Enqueue(key);
+            Assert.IsTrue(entries.TryGetValue(key, out PublicationState? entry));
+            return Task.FromResult(entry);
+        }
+
+        async Task<bool> TryPublishAsync(
+            PublicationState? predecessor,
+            IReadOnlyCollection<Selector> selectors,
+            string key,
+            CancellationToken cancellationToken)
+        {
+            Assert.IsNotNull(predecessor);
+
+            if (predecessor.Id == initial.Id)
+            {
+                if (Interlocked.Increment(ref initialAttempts) == 2)
+                {
+                    bothInitialAttemptsStarted.SetResult(true);
+                }
+
+                await bothInitialAttemptsStarted.Task;
+
+                if (selectors.Contains(firstSelector))
+                {
+                    firstWinner = new PublicationState("first", selectors);
+                    Assert.IsTrue(entries.TryAdd(key, firstWinner));
+                    firstWinnerReady.SetResult(true);
+                    return true;
+                }
+
+                await firstWinnerReady.Task;
+                return false;
+            }
+
+            Assert.AreEqual(firstWinner!.Id, predecessor.Id);
+            finalWinner = new PublicationState("final", selectors);
+            finalWriteKey = key;
+            Assert.IsTrue(entries.TryAdd(key, finalWinner));
+            return true;
+        }
+
+        Task<bool> firstPublication = SelectorPublication.AddAsync(
+            firstSelector,
+            latestKey,
+            QueryAsync,
+            GetConflictWinnerAsync,
+            (state, _) => Task.FromResult<IReadOnlyCollection<Selector>>(state!.Selectors),
+            state => PipelineCachingCacheClient.ComputeSelectorsWriteKey(Universe, weakFingerprint, state?.Id),
+            TryPublishAsync,
+            CancellationToken.None);
+        Task<bool> secondPublication = SelectorPublication.AddAsync(
+            secondSelector,
+            latestKey,
+            QueryAsync,
+            GetConflictWinnerAsync,
+            (state, _) => Task.FromResult<IReadOnlyCollection<Selector>>(state!.Selectors),
+            state => PipelineCachingCacheClient.ComputeSelectorsWriteKey(Universe, weakFingerprint, state?.Id),
+            TryPublishAsync,
+            CancellationToken.None);
+
+        Assert.IsTrue(await firstPublication);
+        Assert.IsTrue(await secondPublication);
+        CollectionAssert.AreEquivalent(
+            new[] { existingSelector, firstSelector, secondSelector },
+            finalWinner!.Selectors.ToArray());
+        string initialWriteKey = PipelineCachingCacheClient.ComputeSelectorsWriteKey(Universe, weakFingerprint, initial.Id);
+        CollectionAssert.AreEqual(new[] { initialWriteKey }, conflictQueries.ToArray());
+        Assert.AreEqual(
+            PipelineCachingCacheClient.ComputeSelectorsWriteKey(Universe, weakFingerprint, firstWinner!.Id),
+            finalWriteKey);
+        StringAssert.StartsWith(latestKey, "selector6|", StringComparison.Ordinal);
+    }
+
+    [TestMethod]
+    public void OutputKeyIncludesSelectorOutput()
+    {
+        Selector firstSelector = CreateSelector(1);
+        Selector secondSelector = CreateSelector(2);
+        Fingerprint weakFingerprint = new("01");
+        StrongFingerprint first = new(weakFingerprint, firstSelector);
+        StrongFingerprint second = new(weakFingerprint, secondSelector);
+
+        string firstKey = PipelineCachingCacheClient.ComputeOutputKey("universe", first, forWrite: false, writeId: 0);
+        string secondKey = PipelineCachingCacheClient.ComputeOutputKey("universe", second, forWrite: false, writeId: 0);
+
+        Assert.AreNotEqual(firstKey, secondKey);
+        StringAssert.StartsWith(firstKey, "outputs6|", StringComparison.Ordinal);
+        StringAssert.Contains(firstKey, "|01|", StringComparison.Ordinal);
+        StringAssert.Contains(secondKey, "|02|", StringComparison.Ordinal);
+    }
+
+    private static Selector CreateSelector(byte output)
+    {
+        byte[] hashBytes = Enumerable.Repeat((byte)0x5a, 32).ToArray();
+        return new Selector(new ContentHash(HashType.SHA256, hashBytes), new[] { output });
+    }
+
+    private sealed class PublicationState
+    {
+        public PublicationState(string id, IEnumerable<Selector> selectors)
+        {
+            Id = id;
+            Selectors = new HashSet<Selector>(selectors);
+        }
+
+        public string Id { get; }
+
+        public HashSet<Selector> Selectors { get; }
+    }
+}

--- a/src/AzurePipelines/Microsoft.MSBuildCache.AzurePipelines.csproj
+++ b/src/AzurePipelines/Microsoft.MSBuildCache.AzurePipelines.csproj
@@ -9,6 +9,9 @@
     <ProjectReference Include="..\Common\Microsoft.MSBuildCache.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.MSBuildCache.AzurePipelines.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Services.PipelineCache.WebApi" />
     <PackageReference Include="Microsoft.VisualStudio.Services.BlobStore.Client" />
     <PackageReference Include="Microsoft.VisualStudio.Services.BlobStore.Client.Cache" />

--- a/src/AzurePipelines/PipelineCachingCacheClient.cs
+++ b/src/AzurePipelines/PipelineCachingCacheClient.cs
@@ -81,7 +81,7 @@ internal sealed class PipelineCachingCacheClient : CacheClient
     private static readonly string DomainId = WellKnownDomainIds.DefaultDomainId.ToString();
 
     private const char KeySegmentSeperator = '|';
-    private const int InternalSeed = 5;
+    private const int InternalSeed = 6;
     private readonly bool _remoteCacheIsReadOnly;
     private readonly string _universe;
     private readonly IAppTraceSource _azureDevopsTracer;
@@ -323,7 +323,37 @@ internal sealed class PipelineCachingCacheClient : CacheClient
         }
 
         // add the WFP -> Selector mapping
-        bool wfpAddded;
+        await _startupTask;
+        string selectorsReadKey = ComputeSelectorsReadKey(_universe, fingerprint.WeakFingerprint);
+        bool wfpAddded = await SelectorPublication.AddAsync(
+            fingerprint.Selector,
+            selectorsReadKey,
+            (key, ct) => QueryPipelineCaching(
+                context,
+                new VisualStudio.Services.PipelineCache.WebApi.Fingerprint(key.Split(KeySegmentSeperator)),
+                ct),
+            (key, ct) => QueryRequiredPipelineCaching(
+                context,
+                new VisualStudio.Services.PipelineCache.WebApi.Fingerprint(key.Split(KeySegmentSeperator)),
+                ct),
+            (predecessor, ct) => ReadSelectorsAsync(context, predecessor, ct),
+            predecessor => ComputeSelectorsWriteKey(_universe, fingerprint.WeakFingerprint, predecessor?.ManifestId.ValueString),
+            (predecessor, selectors, key, ct) => TryPublishSelectorsAsync(context, fingerprint, selectors, key, pathSetBytes, ct),
+            cancellationToken);
+
+        return wfpAddded || sfpAddded
+            ? AddNodeResult.Added
+            : AddNodeResult.AlreadyExists;
+    }
+
+    private async Task<bool> TryPublishSelectorsAsync(
+        Context context,
+        StrongFingerprint fingerprint,
+        IReadOnlyCollection<Selector> selectors,
+        string key,
+        (ContentHash hash, byte[] bytes)? pathSetBytes,
+        CancellationToken cancellationToken)
+    {
         List<TempFile> pathSetTempFiles = new();
         try
         {
@@ -333,12 +363,6 @@ internal sealed class PipelineCachingCacheClient : CacheClient
             FileInfo emptyFileInfo = new(emptyFile.Path);
 
             List<FileInfo> infos = new();
-
-            string key = ComputeSelectorsKey(fingerprint.WeakFingerprint, forWrite: true);
-
-            var selectors = await GetSelectors(context, fingerprint.WeakFingerprint, cancellationToken).ToHashSetAsync(cancellationToken);
-
-            selectors.Add(fingerprint.Selector);
 
             // TODO: limit the number of selectors we store.
 
@@ -364,7 +388,7 @@ internal sealed class PipelineCachingCacheClient : CacheClient
 #pragma warning restore CA2000
 #pragma warning restore IDE0079
 #endif
-                    var bytes = selector.ContentHash == pathSetBytes?.hash
+                    byte[] bytes = selector.ContentHash == pathSetBytes?.hash
                         ? pathSetBytes.Value.bytes
                         : await GetBytes(context, selector.ContentHash.ToBlobIdentifier().ToDedupIdentifier(), cancellationToken);
 #if NETFRAMEWORK
@@ -380,18 +404,19 @@ internal sealed class PipelineCachingCacheClient : CacheClient
             PublishResult result = await WithHttpRetries(
                 () => _manifestClient.PublishAsync(TempFolder, infos, extras, new ArtifactPublishOptions(), manifestFileOutputPath: null, cancellationToken),
                 cacheContext: context,
-                message: $"Publishing content for {fingerprint}",
+                message: $"Publishing selectors for {fingerprint}",
                 cancellationToken);
 
+            var cacheFingerprint = new VisualStudio.Services.PipelineCache.WebApi.Fingerprint(key.Split(KeySegmentSeperator));
             CreatePipelineCacheArtifactContract entry = new(
                 DomainId,
-                new VisualStudio.Services.PipelineCache.WebApi.Fingerprint(key.Split(KeySegmentSeperator)),
+                cacheFingerprint,
                 result.ManifestId,
                 result.RootId,
                 result.ProofNodes,
                 ContentFormatConstants.Files);
 
-            wfpAddded = await WithHttpRetries(
+            return await WithHttpRetries(
                 async () =>
                 {
                     try
@@ -406,16 +431,12 @@ internal sealed class PipelineCachingCacheClient : CacheClient
                     }
                 },
                 cacheContext: context,
-                message: $"Storing cache key for {fingerprint}",
+                message: $"Storing selector cache key for {fingerprint}",
                 cancellationToken);
-
-            return wfpAddded || sfpAddded
-                ? AddNodeResult.Added
-                : AddNodeResult.AlreadyExists;
         }
         finally
         {
-            foreach (var pathSetTempFile in pathSetTempFiles)
+            foreach (TempFile pathSetTempFile in pathSetTempFiles)
             {
                 pathSetTempFile.Dispose();
             }
@@ -618,24 +639,37 @@ internal sealed class PipelineCachingCacheClient : CacheClient
     {
         await _startupTask;
 
-        string key = ComputeSelectorsKey(fingerprint, forWrite: false);
         PipelineCacheArtifact? result = await QueryPipelineCaching(
             context,
-            new VisualStudio.Services.PipelineCache.WebApi.Fingerprint(key.Split(KeySegmentSeperator)),
+            new VisualStudio.Services.PipelineCache.WebApi.Fingerprint(ComputeSelectorsReadKey(_universe, fingerprint).Split(KeySegmentSeperator)),
             cancellationToken);
 
+        foreach (Selector selector in await ReadSelectorsAsync(context, result, cancellationToken))
+        {
+            yield return selector;
+        }
+    }
+
+    private async Task<IReadOnlyCollection<Selector>> ReadSelectorsAsync(
+        Context context,
+        PipelineCacheArtifact? result,
+        CancellationToken cancellationToken)
+    {
         if (result == null)
         {
-            yield break;
+            return [];
         }
 
+        HashSet<Selector> selectors = new();
         using var manifestStream = new MemoryStream(await GetBytes(context, result.ManifestId, cancellationToken));
         Manifest manifest = JsonSerializer.Deserialize<Manifest>(manifestStream)!;
         foreach (ManifestItem selectorItem in manifest.Items.Where(i => i.Path.StartsWith(SelectorsRelativePathBase, StringComparison.Ordinal)))
         {
             string[] tokens = selectorItem.Path.Substring(SelectorsRelativePathBase.Length + 1).Split('/');
-            yield return new Selector(new ContentHash(tokens[0]), HexUtilities.HexToBytes(tokens[1]));
+            selectors.Add(new Selector(new ContentHash(tokens[0]), HexUtilities.HexToBytes(tokens[1])));
         }
+
+        return selectors;
     }
 
     protected override async Task<OpenStreamResult> OpenStreamAsync(Context context, ContentHash contentHash, CancellationToken cancellationToken)
@@ -710,14 +744,34 @@ internal sealed class PipelineCachingCacheClient : CacheClient
     }
 
     private string ComputeKey(StrongFingerprint sfp, bool forWrite) =>
-        forWrite
-            ? $"outputs{InternalSeed}{KeySegmentSeperator}{_universe}{KeySegmentSeperator}{sfp.WeakFingerprint.Serialize()}{KeySegmentSeperator}{sfp.Selector.ContentHash.Serialize()}{KeySegmentSeperator}{DateTime.UtcNow.Ticks}"
-            : $"outputs{InternalSeed}{KeySegmentSeperator}{_universe}{KeySegmentSeperator}{sfp.WeakFingerprint.Serialize()}{KeySegmentSeperator}{sfp.Selector.ContentHash.Serialize()}{KeySegmentSeperator}**";
+        ComputeOutputKey(_universe, sfp, forWrite, DateTime.UtcNow.Ticks);
 
-    private string ComputeSelectorsKey(BuildXL.Cache.MemoizationStore.Interfaces.Sessions.Fingerprint wfp, bool forWrite) =>
+    internal static string ComputeOutputKey(string universe, StrongFingerprint sfp, bool forWrite, long writeId) =>
         forWrite
-            ? $"selector{InternalSeed}{KeySegmentSeperator}{_universe}{KeySegmentSeperator}{wfp.Serialize()}{KeySegmentSeperator}{DateTime.UtcNow.Ticks}"
-            : $"selector{InternalSeed}{KeySegmentSeperator}{_universe}{KeySegmentSeperator}{wfp.Serialize()}{KeySegmentSeperator}**";
+            ? $"outputs{InternalSeed}{KeySegmentSeperator}{universe}{KeySegmentSeperator}{sfp.WeakFingerprint.Serialize()}{KeySegmentSeperator}{sfp.Selector.ContentHash.Serialize()}{KeySegmentSeperator}{sfp.Selector.Output.ToHexString()}{KeySegmentSeperator}{writeId}"
+            : $"outputs{InternalSeed}{KeySegmentSeperator}{universe}{KeySegmentSeperator}{sfp.WeakFingerprint.Serialize()}{KeySegmentSeperator}{sfp.Selector.ContentHash.Serialize()}{KeySegmentSeperator}{sfp.Selector.Output.ToHexString()}{KeySegmentSeperator}**";
+
+    internal static string ComputeSelectorsReadKey(string universe, BuildXL.Cache.MemoizationStore.Interfaces.Sessions.Fingerprint wfp) =>
+        $"selector{InternalSeed}{KeySegmentSeperator}{universe}{KeySegmentSeperator}{wfp.Serialize()}{KeySegmentSeperator}**";
+
+    internal static string ComputeSelectorsWriteKey(
+        string universe,
+        BuildXL.Cache.MemoizationStore.Interfaces.Sessions.Fingerprint wfp,
+        string? predecessorManifestId) =>
+        $"selector{InternalSeed}{KeySegmentSeperator}{universe}{KeySegmentSeperator}{wfp.Serialize()}{KeySegmentSeperator}{predecessorManifestId ?? "root"}";
+
+    private Task<PipelineCacheArtifact> QueryRequiredPipelineCaching(
+        Context context,
+        VisualStudio.Services.PipelineCache.WebApi.Fingerprint key,
+        CancellationToken cancellationToken)
+    {
+        return WithHttpRetries(
+            async () => await QueryPipelineCaching(context, key, cancellationToken)
+                ?? throw new CacheException($"Pipeline Cache entry `{key}` was reported as existing but is not yet visible."),
+            cacheContext: context,
+            message: $"Querying required cache entry '{key}'",
+            cancellationToken);
+    }
 
     private Task<PipelineCacheArtifact?> QueryPipelineCaching(Context context, VisualStudio.Services.PipelineCache.WebApi.Fingerprint key, CancellationToken cancellationToken)
     {

--- a/src/AzurePipelines/SelectorPublication.cs
+++ b/src/AzurePipelines/SelectorPublication.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+
+namespace Microsoft.MSBuildCache.AzurePipelines;
+
+internal static class SelectorPublication
+{
+    internal static async Task<bool> AddAsync<TState>(
+        Selector selector,
+        string latestKey,
+        Func<string, CancellationToken, Task<TState?>> query,
+        Func<string, CancellationToken, Task<TState>> getConflictWinner,
+        Func<TState?, CancellationToken, Task<IReadOnlyCollection<Selector>>> getSelectors,
+        Func<TState?, string> getWriteKey,
+        Func<TState?, IReadOnlyCollection<Selector>, string, CancellationToken, Task<bool>> tryPublish,
+        CancellationToken cancellationToken)
+        where TState : class
+    {
+        TState? predecessor = await query(latestKey, cancellationToken);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            HashSet<Selector> selectors = new(await getSelectors(predecessor, cancellationToken));
+            if (!selectors.Add(selector))
+            {
+                return false;
+            }
+
+            string writeKey = getWriteKey(predecessor);
+            if (await tryPublish(predecessor, selectors, writeKey, cancellationToken))
+            {
+                return true;
+            }
+
+            predecessor = await getConflictWinner(writeKey, cancellationToken);
+        }
+    }
+}

--- a/src/Common.Tests/CasCacheClientTests.cs
+++ b/src/Common.Tests/CasCacheClientTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using BuildXL.Cache.ContentStore.Hashing;
+using BuildXL.Cache.MemoizationStore.Interfaces.Results;
+using BuildXL.Cache.MemoizationStore.Interfaces.Sessions;
+using Microsoft.MSBuildCache.Caching;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.MSBuildCache.Tests;
+
+[TestClass]
+public class CasCacheClientTests
+{
+    [TestMethod]
+    public void NullContentHashListMeansSubmittedValueWasAccepted()
+    {
+        AddOrGetContentHashListResult result = new(default(ContentHashListWithDeterminism));
+
+        Assert.AreEqual(AddNodeResult.Added, CasCacheClient.GetAddNodeResult(result));
+    }
+
+    [TestMethod]
+    public void ReturnedContentHashListMeansAnotherValueWon()
+    {
+        ContentHashList contentHashList = new(Array.Empty<ContentHash>(), null);
+        AddOrGetContentHashListResult result = new(new ContentHashListWithDeterminism(contentHashList, CacheDeterminism.None));
+
+        Assert.AreEqual(AddNodeResult.AlreadyExists, CasCacheClient.GetAddNodeResult(result));
+    }
+}

--- a/src/Common/Caching/CasCacheClient.cs
+++ b/src/Common/Caching/CasCacheClient.cs
@@ -253,11 +253,16 @@ public sealed class CasCacheClient : CacheClient
             throw new CacheException($"{nameof(_twoLevelCacheSession.AddOrGetContentHashListAsync)} failed for {fingerprint}.");
         }
 
-        return contentHashList.Equals(addResult?.ContentHashListWithDeterminism.ContentHashList)
-            ? AddNodeResult.Added
-            : AddNodeResult.AlreadyExists;
+        return GetAddNodeResult(addResult);
 
         // TODO dfederm: Handle CHL races
+    }
+
+    internal static AddNodeResult GetAddNodeResult(AddOrGetContentHashListResult addResult)
+    {
+        return addResult.ContentHashListWithDeterminism.ContentHashList == null
+            ? AddNodeResult.Added
+            : AddNodeResult.AlreadyExists;
     }
 
     protected override async Task<ICacheEntry?> GetCacheEntryAsync(


### PR DESCRIPTION
## Summary

This fixes a race in concurrent Pipeline Cache publication where selector state could be read, merged, and rewritten inconsistently, causing one publisher to lose another publisher’s selector or output identity. The change makes selector publication immutable/serialized, includes the complete selector in output identity, isolates the seed-6 protocol from the legacy layout, and retries conflict-winner visibility when the exact entry is not immediately readable. It also corrects CAS diagnostics so a null `AddOrGetContentHashListResult` is treated as successful acceptance of the submitted value.

## Why this is safe

- Scope is limited to concurrent publication and lookup paths; normal publish/restore behavior is preserved.
- The new seed-6 layout isolates incompatible selector/output keys from legacy writers, so old and new protocols do not mix.
- Conflict-winner retry only applies to required exact-key visibility; ordinary cache misses keep their existing behavior.
- Selector publication now relies on immutable predecessor/successor keys instead of a read/merge/write race.

## Testing

| Test / build | Result |
|---|---|
| `dotnet build MSBuildCache.sln -c Release` | pass |
| `dotnet test MSBuildCache.sln -c Release --no-build` | 532/532 passed |
